### PR TITLE
feat: Refactor query and transaction handling and expand TCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hedera SDK for Zig
 
-The **first** Hedera SDK implementation in Zig. This project is under active development and continues to evolve. It is being built with reference to the [Hedera Technology Compatibility Kit (TCK)](https://github.com/hiero-ledger/hiero-sdk-tck) to help ensure consistency with other official SDKs. Use with care in real-world applications.
+This is Hedera SDK implementation in Zig. This project is under active development and continues to evolve. It is being built with reference to the [Hedera Technology Compatibility Kit (TCK)](https://github.com/hiero-ledger/hiero-sdk-tck) to help ensure consistency with other official SDKs. Use with care in real-world applications.
 
 ## Current Features
 
@@ -56,7 +56,7 @@ zig build test --summary all
 
 ## Breaking Changes
 
-This project is moving quickly, and the API surface may change as new features are introduced or improved. Expect **breaking changes between releases** until the API stabilizes. Please check release notes and update your code accordingly when upgrading.
+This project is moving quickly, and the SDK surface may change as new features are introduced or improved. Expect **breaking changes between releases** until the SDK stabilizes. Please check release notes and update your code accordingly when upgrading.
 
 ## License
 
@@ -75,4 +75,4 @@ For issues, feature requests, or questions:
 
 ---
 
-**Note**: This is the first Hedera SDK for Zig. It is under active development and evolving quickly. While compatibility with the [Hedera Technology Compatibility Kit (TCK)](https://github.com/hiero-ledger/hiero-sdk-tck) is a core goal, please use it thoughtfully and validate thoroughly in your environment before relying on it for critical workloads.
+**Note**: This SDK brings Hedera to Zig for the first time. It is under active development and evolving quickly. While compatibility with the [Hedera Technology Compatibility Kit](https://github.com/hiero-ledger/hiero-sdk-tck) is a core goal, please use it thoughtfully and validate thoroughly in your environment before relying on it for critical workloads.

--- a/build.zig
+++ b/build.zig
@@ -78,68 +78,6 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&run_test.step);
     }
 
-    // Build examples - all are directory-based with main.zig files
-    const examples = [_][]const u8{
-        "account_allowance",
-        "account_create_token_transfer",
-        "account_create_with_alias",
-        "account_create_with_hts",
-        "alias_id_example",
-        "batch_transaction",
-        "clean_account_create",
-        "consensus_pub_sub",
-        "consensus_pub_sub_chunked",
-        "consensus_pub_sub_with_submit_key",
-        "create_account",
-        "create_account_with_threshold_keys",
-        "debug_transaction",
-        "diagnose_account",
-        "create_file",
-        "create_simple_contract",
-        "custom_fees",
-        "delete_account",
-        "delete_file",
-        "file_append_chunked",
-        "generate_key",
-        "generate_key_with_mnemonic",
-        "get_account_balance",
-        "get_file_contents",
-        "multi_app_transfer",
-        "schedule_multisig_transaction",
-        "schedule_transfer_example",
-        "staking",
-        "token_airdrop",
-        "token_create_transfer",
-        "token_reject",
-        "token_update_keys",
-        "token_update_metadata",
-        "token_update_nfts",
-        "topic_with_admin_key",
-        "transfer_crypto",
-        "transfer_tokens",
-        "update_account_public_key",
-        "zero_token_operations",
-    };
-
-    // Build all directory-based examples  
-    for (examples) |example| {
-        const example_exe = b.addExecutable(.{
-            .name = example,
-            .root_source_file = b.path(b.fmt("examples/{s}/main.zig", .{example})),
-            .target = target,
-            .optimize = optimize,
-        });
-        example_exe.root_module.addImport("hedera", hedera_sdk);
-        example_exe.linkLibC();
-        
-        const install_example = b.addInstallArtifact(example_exe, .{});
-        
-        const run_example = b.addRunArtifact(example_exe);
-        const run_example_step = b.step(b.fmt("example-{s}", .{example}), b.fmt("Run {s} example", .{example}));
-        run_example_step.dependOn(&install_example.step);
-        run_example_step.dependOn(&run_example.step);
-    }
-
     // TCK Server
     const tck_exe = b.addExecutable(.{
         .name = "tck-server",

--- a/src/account/account_allowance_approve_transaction.zig
+++ b/src/account/account_allowance_approve_transaction.zig
@@ -151,8 +151,8 @@ pub const AccountAllowanceApproveTransaction = struct {
     }
 
     // Execute the transaction
-    pub fn freezeWith(self: *AccountAllowanceApproveTransaction, client: ?*Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *AccountAllowanceApproveTransaction, client: ?*Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     pub fn execute(self: *AccountAllowanceApproveTransaction, client: *Client) !TransactionResponse {

--- a/src/account/account_allowance_delete_transaction.zig
+++ b/src/account/account_allowance_delete_transaction.zig
@@ -72,8 +72,8 @@ pub const AccountAllowanceDeleteTransaction = struct {
     }
     
     // Execute the transaction
-    pub fn freezeWith(self: *AccountAllowanceDeleteTransaction, client: ?*Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *AccountAllowanceDeleteTransaction, client: ?*Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     pub fn execute(self: *AccountAllowanceDeleteTransaction, client: *Client) !TransactionResponse {

--- a/src/account/account_create.zig
+++ b/src/account/account_create.zig
@@ -175,6 +175,56 @@ pub const AccountCreateTransaction = struct {
         return error.InvalidAlias;
     }
     
+    // Get key
+    pub fn getKey(self: *const Self) ?Key {
+        return self.key;
+    }
+    
+    // Get initial balance
+    pub fn getInitialBalance(self: *const Self) Hbar {
+        return self.initial_balance;
+    }
+    
+    // Get receiver signature required
+    pub fn getReceiverSignatureRequired(self: *const Self) bool {
+        return self.receiver_signature_required;
+    }
+    
+    // Get auto renew period
+    pub fn getAutoRenewPeriod(self: *const Self) Duration {
+        return self.auto_renew_period;
+    }
+    
+    // Get account memo
+    pub fn getAccountMemo(self: *const Self) []const u8 {
+        return self.memo;
+    }
+    
+    // Get max automatic token associations
+    pub fn getMaxAutomaticTokenAssociations(self: *const Self) i32 {
+        return self.max_automatic_token_associations;
+    }
+    
+    // Get staked account ID
+    pub fn getStakedAccountId(self: *const Self) ?AccountId {
+        return self.staked_account_id;
+    }
+    
+    // Get staked node ID
+    pub fn getStakedNodeId(self: *const Self) ?i64 {
+        return self.staked_node_id;
+    }
+    
+    // Get decline staking rewards
+    pub fn getDeclineStakingRewards(self: *const Self) bool {
+        return self.decline_staking_reward;
+    }
+    
+    // Get alias
+    pub fn getAlias(self: *const Self) ?[]const u8 {
+        return self.alias;
+    }
+    
     // Build transaction body for a specific node
     pub fn buildTransactionBodyForNode(self: *Self, node: AccountId) ![]u8 {
         var writer = ProtoWriter.init(self.base.allocator);
@@ -263,8 +313,6 @@ pub const AccountCreateTransaction = struct {
         
         // initialBalance = 2
         try writer.writeUint64(2, @intCast(self.initial_balance.toTinybars()));
-        
-        // proxyAccountID = 3 (field 3 reserved)
         
         // sendRecordThreshold = 6
         try writer.writeUint64(6, @intCast(self.send_record_threshold.toTinybars()));

--- a/src/account/account_delete.zig
+++ b/src/account/account_delete.zig
@@ -60,8 +60,8 @@ pub const AccountDeleteTransaction = struct {
     }
 
     // Execute the transaction
-    pub fn freezeWith(self: *AccountDeleteTransaction, client: ?*Client) !void {
-        _ = try self.base.freezeWith(client);
+    pub fn freezeWith(self: *AccountDeleteTransaction, client: ?*Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     // Sign the transaction with a private key

--- a/src/contract/contract_call_query.zig
+++ b/src/contract/contract_call_query.zig
@@ -22,7 +22,7 @@ pub const ContractCallQuery = struct {
     sender_id: ?AccountId,
     
     pub fn init(allocator: std.mem.Allocator) ContractCallQuery {
-        return ContractCallQuery{
+        var query = ContractCallQuery{
             .base = Query.init(allocator),
             .contract_id = null,
             .gas = 100000,
@@ -31,6 +31,9 @@ pub const ContractCallQuery = struct {
             .max_result_size = 1024,
             .sender_id = null,
         };
+        query.base.grpc_service_name = "proto.SmartContractService";
+        query.base.grpc_method_name = "contractCallLocalMethod";
+        return query;
     }
     
     pub fn deinit(self: *ContractCallQuery) void {

--- a/src/contract/contract_delete.zig
+++ b/src/contract/contract_delete.zig
@@ -29,53 +29,53 @@ pub const ContractDeleteTransaction = struct {
         self.base.deinit();
     }
     
-    // SetContractID sets the contract to delete
-    pub fn SetContractID(self: *ContractDeleteTransaction, contract_id: ContractId) HederaError!*ContractDeleteTransaction {
+    // Set the contract to delete
+    pub fn setContractId(self: *ContractDeleteTransaction, contract_id: ContractId) HederaError!*ContractDeleteTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.contract_id = contract_id;
         return self;
     }
     
-    // GetContractID returns the contract to delete
-    pub fn GetContractID(self: *const ContractDeleteTransaction) ContractId {
+    // Get the contract to delete
+    pub fn getContractId(self: *const ContractDeleteTransaction) ContractId {
         return self.contract_id orelse ContractId{};
     }
     
-    // SetTransferAccountID sets the account to transfer remaining balance to
-    pub fn SetTransferAccountID(self: *ContractDeleteTransaction, account_id: AccountId) HederaError!*ContractDeleteTransaction {
+    // Set the account to transfer remaining balance to
+    pub fn setTransferAccountId(self: *ContractDeleteTransaction, account_id: AccountId) HederaError!*ContractDeleteTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.transfer_account_id = account_id;
         self.transfer_contract_id = null; // Clear contract ID when setting account ID
         return self;
     }
     
-    // GetTransferAccountID returns the account to transfer remaining balance to
-    pub fn GetTransferAccountID(self: *const ContractDeleteTransaction) AccountId {
+    // Get the account to transfer remaining balance to
+    pub fn getTransferAccountId(self: *const ContractDeleteTransaction) AccountId {
         return self.transfer_account_id orelse AccountId{};
     }
     
-    // SetTransferContractID sets the contract to transfer remaining balance to
-    pub fn SetTransferContractID(self: *ContractDeleteTransaction, contract_id: ContractId) HederaError!*ContractDeleteTransaction {
+    // Set the contract to transfer remaining balance to
+    pub fn setTransferContractId(self: *ContractDeleteTransaction, contract_id: ContractId) HederaError!*ContractDeleteTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.transfer_contract_id = contract_id;
         self.transfer_account_id = null; // Clear account ID when setting contract ID
         return self;
     }
     
-    // GetTransferContractID returns the contract to transfer remaining balance to
-    pub fn GetTransferContractID(self: *const ContractDeleteTransaction) ContractId {
+    // Get the contract to transfer remaining balance to
+    pub fn getTransferContractId(self: *const ContractDeleteTransaction) ContractId {
         return self.transfer_contract_id orelse ContractId{};
     }
     
-    // SetPermanentRemoval sets the permanent removal flag
-    pub fn SetPermanentRemoval(self: *ContractDeleteTransaction, permanent: bool) HederaError!*ContractDeleteTransaction {
+    // Set the permanent removal flag
+    pub fn setPermanentRemoval(self: *ContractDeleteTransaction, permanent: bool) HederaError!*ContractDeleteTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.permanent_removal = permanent;
         return self;
     }
     
-    // GetPermanentRemoval returns the permanent removal flag
-    pub fn GetPermanentRemoval(self: *const ContractDeleteTransaction) bool {
+    // Get the permanent removal flag
+    pub fn getPermanentRemoval(self: *const ContractDeleteTransaction) bool {
         return self.permanent_removal;
     }
     

--- a/src/contract/contract_info_query.zig
+++ b/src/contract/contract_info_query.zig
@@ -627,7 +627,7 @@ pub const ContractInfoQuery = struct {
                             4 => {
                                 // adminKey
                                 const key_bytes = try contract_reader.readMessage();
-                                info.admin_key = try Key.fromProtobuf(key_bytes, self.base.allocator);
+                                info.admin_key = try Key.fromProtobuf(self.base.allocator, key_bytes);
                             },
                             5 => {
                                 // expirationTime

--- a/src/contract/contract_update_transaction.zig
+++ b/src/contract/contract_update_transaction.zig
@@ -17,7 +17,6 @@ pub const ContractUpdateTransaction = struct {
     contract_id: ?ContractId = null,
     expiration_time: ?Timestamp = null,
     admin_key: ?Key = null,
-    proxy_account_id: ?AccountId = null,
     auto_renew_period: ?Duration = null,
     file_id: ?FileId = null,
     contract_memo: ?[]const u8 = null,
@@ -41,79 +40,55 @@ pub const ContractUpdateTransaction = struct {
     }
     
     // SetContractID sets the contract ID to update
-    pub fn SetContractID(self: *ContractUpdateTransaction, contract_id: ContractId) HederaError!*ContractUpdateTransaction {
+    pub fn setContractId(self: *ContractUpdateTransaction, contract_id: ContractId) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.contract_id = contract_id;
         return self;
     }
     
     // GetContractID returns the contract ID to update
-    pub fn GetContractID(self: *const ContractUpdateTransaction) ContractId {
+    pub fn getContractId(self: *const ContractUpdateTransaction) ContractId {
         return self.contract_id orelse ContractId{};
     }
     
     // SetExpirationTime sets the expiration time for the contract
-    pub fn SetExpirationTime(self: *ContractUpdateTransaction, expiration_time: Timestamp) HederaError!*ContractUpdateTransaction {
+    pub fn setExpirationTime(self: *ContractUpdateTransaction, expiration_time: Timestamp) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.expiration_time = expiration_time;
         return self;
     }
     
     // GetExpirationTime returns the expiration time for the contract
-    pub fn GetExpirationTime(self: *const ContractUpdateTransaction) Timestamp {
+    pub fn getExpirationTime(self: *const ContractUpdateTransaction) Timestamp {
         return self.expiration_time orelse Timestamp{};
     }
     
     // SetAdminKey sets the admin key for the contract
-    pub fn SetAdminKey(self: *ContractUpdateTransaction, key: Key) HederaError!*ContractUpdateTransaction {
+    pub fn setAdminKey(self: *ContractUpdateTransaction, key: Key) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.admin_key = key;
         return self;
     }
     
     // GetAdminKey returns the admin key for the contract
-    pub fn GetAdminKey(self: *const ContractUpdateTransaction) ?Key {
+    pub fn getAdminKey(self: *const ContractUpdateTransaction) ?Key {
         return self.admin_key;
     }
-    
-    // SetProxyAccountID sets the proxy account ID (deprecated)
-    pub fn SetProxyAccountID(self: *ContractUpdateTransaction, proxy_account_id: AccountId) HederaError!*ContractUpdateTransaction {
-        if (self.base.frozen) return error.TransactionFrozen;
-        self.proxy_account_id = proxy_account_id;
-        return self;
-    }
-    
-    // GetProxyAccountID returns the proxy account ID (deprecated)
-    pub fn GetProxyAccountID(self: *const ContractUpdateTransaction) AccountId {
-        return self.proxy_account_id orelse AccountId{};
-    }
-    
     // SetAutoRenewPeriod sets the auto renew period for the contract
-    pub fn SetAutoRenewPeriod(self: *ContractUpdateTransaction, period: Duration) HederaError!*ContractUpdateTransaction {
+    pub fn setAutoRenewPeriod(self: *ContractUpdateTransaction, period: Duration) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.auto_renew_period = period;
         return self;
     }
     
     // GetAutoRenewPeriod returns the auto renew period for the contract
-    pub fn GetAutoRenewPeriod(self: *const ContractUpdateTransaction) Duration {
+    pub fn getAutoRenewPeriod(self: *const ContractUpdateTransaction) Duration {
         return self.auto_renew_period orelse Duration{};
     }
     
-    // SetBytecodeFileID sets the file ID containing new bytecode (deprecated)
-    pub fn SetBytecodeFileID(self: *ContractUpdateTransaction, file_id: FileId) HederaError!*ContractUpdateTransaction {
-        if (self.base.frozen) return error.TransactionFrozen;
-        self.file_id = file_id;
-        return self;
-    }
-    
-    // GetBytecodeFileID returns the file ID containing new bytecode (deprecated)
-    pub fn GetBytecodeFileID(self: *const ContractUpdateTransaction) FileId {
-        return self.file_id orelse FileId{};
-    }
     
     // SetContractMemo sets the memo for the contract
-    pub fn SetContractMemo(self: *ContractUpdateTransaction, memo: []const u8) HederaError!*ContractUpdateTransaction {
+    pub fn setContractMemo(self: *ContractUpdateTransaction, memo: []const u8) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         
         if (self.contract_memo) |old_memo| {
@@ -125,12 +100,12 @@ pub const ContractUpdateTransaction = struct {
     }
     
     // GetContractMemo returns the memo for the contract
-    pub fn GetContractMemo(self: *const ContractUpdateTransaction) []const u8 {
+    pub fn getContractMemo(self: *const ContractUpdateTransaction) []const u8 {
         return self.contract_memo orelse "";
     }
     
     // ClearContractMemo clears the contract memo
-    pub fn ClearContractMemo(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
+    pub fn clearContractMemo(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         
         if (self.contract_memo) |memo| {
@@ -142,38 +117,38 @@ pub const ContractUpdateTransaction = struct {
     }
     
     // SetMaxAutomaticTokenAssociations sets the maximum number of automatic token associations
-    pub fn SetMaxAutomaticTokenAssociations(self: *ContractUpdateTransaction, max: i32) HederaError!*ContractUpdateTransaction {
+    pub fn setMaxAutomaticTokenAssociations(self: *ContractUpdateTransaction, max: i32) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.max_automatic_token_associations = max;
         return self;
     }
     
     // GetMaxAutomaticTokenAssociations returns the maximum number of automatic token associations
-    pub fn GetMaxAutomaticTokenAssociations(self: *const ContractUpdateTransaction) i32 {
+    pub fn getMaxAutomaticTokenAssociations(self: *const ContractUpdateTransaction) i32 {
         return self.max_automatic_token_associations orelse 0;
     }
     
     // SetAutoRenewAccountID sets the auto renew account ID for the contract
-    pub fn SetAutoRenewAccountID(self: *ContractUpdateTransaction, account_id: AccountId) HederaError!*ContractUpdateTransaction {
+    pub fn setAutoRenewAccountId(self: *ContractUpdateTransaction, account_id: AccountId) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.auto_renew_account_id = account_id;
         return self;
     }
     
     // GetAutoRenewAccountID returns the auto renew account ID for the contract
-    pub fn GetAutoRenewAccountID(self: *const ContractUpdateTransaction) AccountId {
+    pub fn getAutoRenewAccountId(self: *const ContractUpdateTransaction) AccountId {
         return self.auto_renew_account_id orelse AccountId{};
     }
     
     // ClearAutoRenewAccountID clears the auto renew account ID
-    pub fn ClearAutoRenewAccountID(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
+    pub fn clearAutoRenewAccountId(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.auto_renew_account_id = null;
         return self;
     }
     
     // SetStakedAccountID sets the staked account ID for the contract
-    pub fn SetStakedAccountID(self: *ContractUpdateTransaction, account_id: AccountId) HederaError!*ContractUpdateTransaction {
+    pub fn setStakedAccountId(self: *ContractUpdateTransaction, account_id: AccountId) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.staked_account_id = account_id;
         self.staked_node_id = null; // Clear node ID when setting account ID
@@ -181,12 +156,12 @@ pub const ContractUpdateTransaction = struct {
     }
     
     // GetStakedAccountID returns the staked account ID for the contract
-    pub fn GetStakedAccountID(self: *const ContractUpdateTransaction) AccountId {
+    pub fn getStakedAccountId(self: *const ContractUpdateTransaction) AccountId {
         return self.staked_account_id orelse AccountId{};
     }
     
     // SetStakedNodeID sets the staked node ID for the contract
-    pub fn SetStakedNodeID(self: *ContractUpdateTransaction, node_id: i64) HederaError!*ContractUpdateTransaction {
+    pub fn setStakedNodeId(self: *ContractUpdateTransaction, node_id: i64) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.staked_node_id = node_id;
         self.staked_account_id = null; // Clear account ID when setting node ID
@@ -194,33 +169,33 @@ pub const ContractUpdateTransaction = struct {
     }
     
     // GetStakedNodeID returns the staked node ID for the contract
-    pub fn GetStakedNodeID(self: *const ContractUpdateTransaction) i64 {
+    pub fn getStakedNodeId(self: *const ContractUpdateTransaction) i64 {
         return self.staked_node_id orelse 0;
     }
     
     // ClearStakedAccountID clears the staked account ID
-    pub fn ClearStakedAccountID(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
+    pub fn clearStakedAccountId(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.staked_account_id = AccountId{ .account = 0 };
         return self;
     }
     
     // ClearStakedNodeID clears the staked node ID
-    pub fn ClearStakedNodeID(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
+    pub fn clearStakedNodeId(self: *ContractUpdateTransaction) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.staked_node_id = -1;
         return self;
     }
     
     // SetDeclineStakingReward sets whether to decline staking rewards
-    pub fn SetDeclineStakingReward(self: *ContractUpdateTransaction, decline: bool) HederaError!*ContractUpdateTransaction {
+    pub fn setDeclineStakingReward(self: *ContractUpdateTransaction, decline: bool) HederaError!*ContractUpdateTransaction {
         if (self.base.frozen) return error.TransactionFrozen;
         self.decline_staking_reward = decline;
         return self;
     }
     
     // GetDeclineStakingReward returns whether to decline staking rewards
-    pub fn GetDeclineStakingReward(self: *const ContractUpdateTransaction) bool {
+    pub fn getDeclineStakingReward(self: *const ContractUpdateTransaction) bool {
         return self.decline_staking_reward orelse false;
     }
     
@@ -269,18 +244,6 @@ pub const ContractUpdateTransaction = struct {
             const key_bytes = try key.toProtobuf(self.base.allocator);
             defer self.base.allocator.free(key_bytes);
             try contract_writer.writeMessage(3, key_bytes);
-        }
-        
-        // proxyAccountID = 6 (deprecated)
-        if (self.proxy_account_id) |proxy| {
-            var proxy_writer = ProtoWriter.init(self.base.allocator);
-            defer proxy_writer.deinit();
-            try proxy_writer.writeInt64(1, @intCast(proxy.shard));
-            try proxy_writer.writeInt64(2, @intCast(proxy.realm));
-            try proxy_writer.writeInt64(3, @intCast(proxy.account));
-            const proxy_bytes = try proxy_writer.toOwnedSlice();
-            defer self.base.allocator.free(proxy_bytes);
-            try contract_writer.writeMessage(6, proxy_bytes);
         }
         
         // autoRenewPeriod = 7

--- a/src/crypto/mnemonic.zig
+++ b/src/crypto/mnemonic.zig
@@ -7,7 +7,7 @@ pub const Mnemonic = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator, words: [][]const u8) !Mnemonic {
-        // Validate word count - support 12, 22 (legacy), and 24 words
+        // Validate word count - support 12, 22, and 24 words
         if (words.len != 12 and words.len != 22 and words.len != 24) {
             return error.InvalidMnemonicLength;
         }

--- a/src/file/file_append.zig
+++ b/src/file/file_append.zig
@@ -124,9 +124,9 @@ pub const FileAppendTransaction = struct {
             // Set transaction ID with nonce for chunks after the first
             if (i > 0) {
                 const chunk_tx_id = initial_tx_id.withNonce(@intCast(i));
-                try chunk_tx.base.setTransactionId(chunk_tx_id);
+                _ = try chunk_tx.base.setTransactionId(chunk_tx_id);
             } else {
-                try chunk_tx.base.setTransactionId(initial_tx_id);
+                _ = try chunk_tx.base.setTransactionId(initial_tx_id);
             }
             
             // Copy other transaction settings

--- a/src/file/file_info_query.zig
+++ b/src/file/file_info_query.zig
@@ -23,7 +23,7 @@ pub const FileInfo = struct {
     
     pub fn init(allocator: std.mem.Allocator) FileInfo {
         return FileInfo{
-            .file_id = FileId.init(0, 0, 0),
+            .file_id = FileId{ .entity = .{ .shard = 0, .realm = 0, .num = 0 } },
             .size = 0,
             .expiration_time = Timestamp{ .seconds = 0, .nanos = 0 },
             .deleted = false,
@@ -52,10 +52,14 @@ pub const FileInfoQuery = struct {
     file_id: ?FileId,
     
     pub fn init(allocator: std.mem.Allocator) FileInfoQuery {
-        return FileInfoQuery{
+        var query = FileInfoQuery{
             .base = Query.init(allocator),
             .file_id = null,
         };
+        query.base.grpc_service_name = "proto.FileService";
+        query.base.grpc_method_name = "getFileInfo";
+        query.base.is_payment_required = true;
+        return query;
     }
     
     pub fn deinit(self: *FileInfoQuery) void {
@@ -80,7 +84,12 @@ pub const FileInfoQuery = struct {
             return error.FileIdRequired;
         }
         
-        const response = try self.base.execute(client);
+        // Build the query bytes directly
+        const query_bytes = try self.buildQuery();
+        defer self.base.allocator.free(query_bytes);
+        
+        // Execute with the built bytes
+        const response = try self.base.executeWithBytes(client, query_bytes);
         return try self.parseResponse(response);
     }
     
@@ -111,42 +120,40 @@ pub const FileInfoQuery = struct {
         var writer = ProtoWriter.init(self.base.allocator);
         defer writer.deinit();
         
-        // Query message structure
-        // header = 1
-        var header_writer = ProtoWriter.init(self.base.allocator);
-        defer header_writer.deinit();
-        
-        // payment = 1
-        if (self.base.payment_transaction) |payment| {
-            try header_writer.writeMessage(1, payment);
-        }
-        
-        // responseType = 2
-        try header_writer.writeInt32(2, @intFromEnum(self.base.response_type));
-        
-        const header_bytes = try header_writer.toOwnedSlice();
-        defer self.base.allocator.free(header_bytes);
-        try writer.writeMessage(1, header_bytes);
-        
-        // fileGetInfo = 6 (oneof query)
+        // fileGetInfo = 8 (oneof query)
         var info_query_writer = ProtoWriter.init(self.base.allocator);
         defer info_query_writer.deinit();
         
-        // fileID = 1
+        // header = 1 (inside the specific query)
+        var header_writer = ProtoWriter.init(self.base.allocator);
+        defer header_writer.deinit();
+        
+        // payment = 1 (optional)
+        // Payment handling will be added when needed
+        
+        // responseType = 2 (must be present even if 0)
+        try header_writer.writeTag(2, .Varint);
+        try header_writer.writeVarint(@as(u64, @intCast(@intFromEnum(self.base.response_type))));
+        
+        const header_bytes = try header_writer.toOwnedSlice();
+        defer self.base.allocator.free(header_bytes);
+        try info_query_writer.writeMessage(1, header_bytes);
+        
+        // fileID = 2
         if (self.file_id) |file| {
             var file_writer = ProtoWriter.init(self.base.allocator);
             defer file_writer.deinit();
-            try file_writer.writeInt64(1, @intCast(file.shard));
-            try file_writer.writeInt64(2, @intCast(file.realm));
-            try file_writer.writeInt64(3, @intCast(file.num));
+            try file_writer.writeInt64(1, @intCast(file.entity.shard));
+            try file_writer.writeInt64(2, @intCast(file.entity.realm));
+            try file_writer.writeInt64(3, @intCast(file.entity.num));
             const file_bytes = try file_writer.toOwnedSlice();
             defer self.base.allocator.free(file_bytes);
-            try info_query_writer.writeMessage(1, file_bytes);
+            try info_query_writer.writeMessage(2, file_bytes);
         }
         
         const info_query_bytes = try info_query_writer.toOwnedSlice();
         defer self.base.allocator.free(info_query_bytes);
-        try writer.writeMessage(6, info_query_bytes);
+        try writer.writeMessage(8, info_query_bytes);
         
         return writer.toOwnedSlice();
     }
@@ -158,7 +165,7 @@ pub const FileInfoQuery = struct {
         var reader = ProtoReader.init(response.response_bytes);
         
         var info = FileInfo{
-            .file_id = FileId.init(0, 0, 0),
+            .file_id = FileId{ .entity = .{ .shard = 0, .realm = 0, .num = 0 } },
             .size = 0,
             .expiration_time = Timestamp{ .seconds = 0, .nanos = 0 },
             .deleted = false,
@@ -205,7 +212,7 @@ pub const FileInfoQuery = struct {
                                     }
                                 }
                                 
-                                info.file_id = FileId.init(@intCast(shard), @intCast(realm), @intCast(num));
+                                info.file_id = FileId{ .entity = .{ .shard = @intCast(shard), .realm = @intCast(realm), .num = @intCast(num) } };
                             },
                             2 => info.size = try file_reader.readInt64(),
                             3 => {
@@ -235,7 +242,7 @@ pub const FileInfoQuery = struct {
                                         1 => {
                                             // keys (repeated)
                                             const key_bytes = try keys_reader.readMessage();
-                                            const key = try Key.fromProtobuf(key_bytes, self.base.allocator);
+                                            const key = try Key.fromProtobuf(self.base.allocator, key_bytes);
                                             try info.keys.append(key);
                                         },
                                         else => try keys_reader.skipField(k_tag.wire_type),

--- a/src/flow/contract_create_flow.zig
+++ b/src/flow/contract_create_flow.zig
@@ -35,7 +35,7 @@ pub const ContractCreateFlow = struct {
             .bytecode = &[_]u8{},
             .gas = 100000,
             .initial_balance = Hbar.init(0),
-            .auto_renew_period = Duration.init(131500 * 60), // 131500 minutes default
+            .auto_renew_period = Duration.init(7776000), // 90 days
             .parameters = &[_]u8{},
             .node_account_ids = std.ArrayList(AccountId).init(allocator),
             .create_bytecode = &[_]u8{},
@@ -114,13 +114,6 @@ pub const ContractCreateFlow = struct {
         self.auto_renew_period = period;
         return self;
     }
-    
-    // Set proxy account ID (deprecated)
-    pub fn setProxyAccountId(self: *ContractCreateFlow, proxy_account_id: AccountId) !*ContractCreateFlow {
-        self.proxy_account_id = proxy_account_id;
-        return self;
-    }
-    
     // Set constructor parameters
     pub fn setConstructorParameters(self: *ContractCreateFlow, params: *ContractFunctionParameters) !*ContractCreateFlow {
         if (self.parameters.len > 0) self.allocator.free(self.parameters);

--- a/src/hedera.zig
+++ b/src/hedera.zig
@@ -73,7 +73,7 @@ pub const BatchTransaction = @import("transaction/batch_transaction.zig").BatchT
 
 // Node Management operations
 pub const NodeCreateTransaction = @import("node/node_create_transaction.zig").NodeCreateTransaction;
-// ServiceEndpoint is defined below in managed_node.zig
+pub const NodeServiceEndpoint = @import("node/node_create_transaction.zig").ServiceEndpoint;
 
 // LiveHash operations for cryptographic proofs
 pub const LiveHashAddTransaction = @import("crypto/live_hash.zig").LiveHashAddTransaction;
@@ -83,6 +83,7 @@ pub const LiveHash = @import("crypto/live_hash.zig").LiveHash;
 // Query base
 pub const Query = @import("query/query.zig").Query;
 pub const QueryResponse = @import("query/query.zig").QueryResponse;
+pub const CostQuery = @import("query/cost_query.zig").CostQuery;
 
 // Account operations
 pub const AccountCreateTransaction = @import("account/account_create.zig").AccountCreateTransaction;
@@ -166,7 +167,10 @@ pub const TokenCancelAirdropTransaction = @import("token/token_cancel_airdrop_tr
 pub const TokenClaimAirdropTransaction = @import("token/token_claim_airdrop_transaction.zig").TokenClaimAirdropTransaction;
 pub const TokenRejectTransaction = @import("token/token_reject_transaction.zig").TokenRejectTransaction;
 pub const TokenUpdateNftsTransaction = @import("token/token_update_nfts_transaction.zig").TokenUpdateNftsTransaction;
-pub const PendingAirdropId = @import("token/token_cancel_airdrop_transaction.zig").PendingAirdropId;
+pub const PendingAirdropId = @import("token/pending_airdrop_id.zig").PendingAirdropId;
+pub const AirdropPendingTransaction = @import("token/airdrop_pending_transaction.zig").AirdropPendingTransaction;
+pub const AbstractTokenTransferTransaction = @import("token/abstract_token_transfer_transaction.zig").AbstractTokenTransferTransaction;
+pub const TokenTransferList = @import("token/abstract_token_transfer_transaction.zig").TokenTransferList;
 pub const TokenReference = @import("token/token_reject_transaction.zig").TokenReference;
 
 // Smart contract operations
@@ -596,6 +600,10 @@ pub fn tokenRejectTransaction(allocator: std.mem.Allocator) TokenRejectTransacti
     return TokenRejectTransaction.init(allocator);
 }
 
+pub fn airdropPendingTransaction(allocator: std.mem.Allocator) AirdropPendingTransaction {
+    return AirdropPendingTransaction.init(allocator);
+}
+
 // File operations constructors
 pub fn fileCreateTransaction(allocator: std.mem.Allocator) FileCreateTransaction {
     return FileCreateTransaction.init(allocator);
@@ -822,6 +830,10 @@ pub fn mirrorNodeContractCallQuery(allocator: std.mem.Allocator) MirrorNodeContr
 
 pub fn mirrorNodeContractEstimateGasQuery(allocator: std.mem.Allocator) MirrorNodeContractEstimateGasQuery {
     return MirrorNodeContractEstimateGasQuery.init(allocator);
+}
+
+pub fn costQuery(allocator: std.mem.Allocator) CostQuery {
+    return CostQuery.init(allocator);
 }
 
 test "basic initialization" {

--- a/src/network/client.zig
+++ b/src/network/client.zig
@@ -239,7 +239,7 @@ pub const Client = struct {
     }
     
     // Submit transaction to network
-    pub fn submitTransaction(self: *Client, tx_bytes: []const u8, node_account_id: AccountId) !void {
+    pub fn submitTransaction(self: *Client, tx_bytes: []const u8, node_account_id: AccountId, service_name: []const u8, method_name: []const u8) !void {
         if (self.closed) return HederaError.ClientClosed;
         
         const max_attempts = self.config.max_attempts;
@@ -275,8 +275,8 @@ pub const Client = struct {
             
             // Submit transaction via gRPC
             _ = conn.call(
-                "proto.CryptoService",
-                "createAccount",
+                service_name,
+                method_name,
                 tx_bytes
             ) catch |err| {
                 node.increaseBackoff();
@@ -353,7 +353,7 @@ pub const Client = struct {
                 continue;
             };
             
-            // Submit query via gRPC
+            // Submit query via gRPC  
             const response = conn.call(
                 "proto.CryptoService",
                 "getTransactionReceipts",
@@ -378,7 +378,7 @@ pub const Client = struct {
         return last_error;
     }
     
-    // Execute generic query request on network
+    // Execute generic query request on network  
     pub fn executeQueryRequest(self: *Client, query_bytes: []const u8, node_account_id: AccountId, service_name: []const u8, method_name: []const u8) ![]u8 {
         if (self.closed) return HederaError.ClientClosed;
         

--- a/src/query/cost_query.zig
+++ b/src/query/cost_query.zig
@@ -1,0 +1,234 @@
+// Query for getting the cost of another query
+// Returns the estimated cost in Hbar before executing the actual query
+
+const std = @import("std");
+const Query = @import("query.zig").Query;
+const Hbar = @import("../core/hbar.zig").Hbar;
+const AccountId = @import("../core/id.zig").AccountId;
+const TransactionId = @import("../core/transaction_id.zig").TransactionId;
+const ProtoWriter = @import("../protobuf/writer.zig").ProtoWriter;
+const ProtoReader = @import("../protobuf/reader.zig").ProtoReader;
+const HederaError = @import("../core/errors.zig").HederaError;
+const Client = @import("../network/client.zig").Client;
+
+// Query to get the cost of executing another query
+pub const CostQuery = struct {
+    base: Query,
+    target_query: ?*Query = null,
+    
+    const Self = @This();
+    
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return Self{
+            .base = Query.init(allocator),
+        };
+    }
+    
+    pub fn deinit(self: *Self) void {
+        self.base.deinit();
+    }
+    
+    // Set the query to get the cost for
+    pub fn setQuery(self: *Self, query: *Query) HederaError!*Self {
+        self.target_query = query;
+        
+        // Copy settings from target query
+        self.base.node_account_ids = query.node_account_ids;
+        self.base.payment = query.payment;
+        
+        return self;
+    }
+    
+    // Get the target query
+    pub fn getQuery(self: *const Self) ?*Query {
+        return self.target_query;
+    }
+    
+    // Build the query header
+    fn buildQueryHeader(self: *Self, node: AccountId) ![]u8 {
+        _ = node;
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        // payment = 1
+        if (self.base.payment) |payment| {
+            const payment_bytes = try payment.toProtobuf(self.base.allocator);
+            defer self.base.allocator.free(payment_bytes);
+            try writer.writeMessage(1, payment_bytes);
+        }
+        
+        // responseType = 2 (COST_ANSWER = 1)
+        try writer.writeInt32(2, 1);
+        
+        return writer.toOwnedSlice();
+    }
+    
+    // Build query for a specific node
+    pub fn buildQueryForNode(self: *Self, node: AccountId) ![]u8 {
+        if (self.target_query == null) {
+            return HederaError.InvalidParameter;
+        }
+        
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        // Build the target query with COST_ANSWER response type
+        const target_bytes = try self.target_query.?.buildQueryForNode(node);
+        defer self.base.allocator.free(target_bytes);
+        
+        // Parse the target query to modify its response type
+        var reader = ProtoReader.init(target_bytes);
+        var modified_writer = ProtoWriter.init(self.base.allocator);
+        defer modified_writer.deinit();
+        
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            
+            // Copy all fields but modify the query header
+            if (tag.field_number == 1) {
+                // This is the query header
+                const header_bytes = try reader.readBytes();
+                const modified_header = try self.modifyQueryHeader(header_bytes);
+                defer self.base.allocator.free(modified_header);
+                try modified_writer.writeMessage(1, modified_header);
+            } else {
+                // Copy other fields as-is
+                switch (tag.wire_type) {
+                    0 => {
+                        const value = try reader.readVarint();
+                        try modified_writer.writeVarint(tag.field_number, value);
+                    },
+                    1 => {
+                        const value = try reader.readFixed64();
+                        try modified_writer.writeFixed64(tag.field_number, value);
+                    },
+                    2 => {
+                        const value = try reader.readBytes();
+                        try modified_writer.writeBytesField(tag.field_number, value);
+                    },
+                    5 => {
+                        const value = try reader.readFixed32();
+                        try modified_writer.writeFixed32(tag.field_number, value);
+                    },
+                    else => return HederaError.InvalidParameter,
+                }
+            }
+        }
+        
+        return modified_writer.toOwnedSlice();
+    }
+    
+    // Modify query header to set COST_ANSWER response type
+    fn modifyQueryHeader(self: *Self, header_bytes: []const u8) ![]u8 {
+        var reader = ProtoReader.init(header_bytes);
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            
+            if (tag.field_number == 2) {
+                // responseType field - set to COST_ANSWER (1)
+                try writer.writeInt32(2, 1);
+                _ = try reader.readVarint(); // Skip the original value
+            } else {
+                // Copy other fields as-is
+                switch (tag.wire_type) {
+                    0 => {
+                        const value = try reader.readVarint();
+                        try writer.writeVarint(tag.field_number, value);
+                    },
+                    1 => {
+                        const value = try reader.readFixed64();
+                        try writer.writeFixed64(tag.field_number, value);
+                    },
+                    2 => {
+                        const value = try reader.readBytes();
+                        try writer.writeBytesField(tag.field_number, value);
+                    },
+                    5 => {
+                        const value = try reader.readFixed32();
+                        try writer.writeFixed32(tag.field_number, value);
+                    },
+                    else => return HederaError.InvalidParameter,
+                }
+            }
+        }
+        
+        return writer.toOwnedSlice();
+    }
+    
+    // Execute the query
+    pub fn execute(self: *Self, client: *Client) !Hbar {
+        if (self.target_query == null) {
+            return HederaError.InvalidParameter;
+        }
+        
+        // Set default payment if not set
+        if (self.base.payment == null) {
+            self.base.payment = try Hbar.fromTinybars(0);
+        }
+        
+        // Execute the query
+        const response_bytes = try self.base.executeWithClient(client, self);
+        defer self.base.allocator.free(response_bytes);
+        
+        // Parse response to get cost
+        return self.parseCostResponse(response_bytes);
+    }
+    
+    // Parse the cost response
+    fn parseCostResponse(self: *Self, response_bytes: []const u8) !Hbar {
+        _ = self;
+        var reader = ProtoReader.init(response_bytes);
+        
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            
+            switch (tag.field_number) {
+                1 => {
+                    // header
+                    const header_bytes = try reader.readBytes();
+                    _ = header_bytes; // Process header if needed
+                },
+                2 => {
+                    // cost
+                    const cost = try reader.readUint64();
+                    return Hbar.fromTinybars(@intCast(cost));
+                },
+                else => try reader.skipField(tag.wire_type),
+            }
+        }
+        
+        return HederaError.InvalidResponse;
+    }
+    
+    // Set node account IDs
+    pub fn setNodeAccountIds(self: *Self, node_account_ids: []const AccountId) !*Self {
+        try self.base.setNodeAccountIds(node_account_ids);
+        return self;
+    }
+    
+    // Set query payment
+    pub fn setQueryPayment(self: *Self, payment: Hbar) !*Self {
+        self.base.payment = payment;
+        return self;
+    }
+    
+    // Set max query payment
+    pub fn setMaxQueryPayment(self: *Self, max_payment: Hbar) !*Self {
+        self.base.max_query_payment = max_payment;
+        return self;
+    }
+    
+    // Get the cost without executing
+    pub fn getCost(self: *Self, client: *Client) !Hbar {
+        return self.execute(client);
+    }
+    
+    // Wrapper function for Query base class function pointer
+    pub fn buildQueryForNodeWrapper(query: *Query, node: AccountId) anyerror![]u8 {
+        const self = @as(*CostQuery, @fieldParentPtr("base", query));
+        return self.buildQueryForNode(node);
+    }
+};

--- a/src/query/receipt_query.zig
+++ b/src/query/receipt_query.zig
@@ -70,7 +70,9 @@ pub const TransactionReceiptQuery = struct {
             .include_children = false,
             .include_duplicates = false,
         };
-        query.base.is_payment_required = false; // Receipts are free
+        query.base.grpc_service_name = "proto.CryptoService";
+        query.base.grpc_method_name = "getTransactionReceipts";
+        query.base.is_payment_required = false;
         return query;
     }
     

--- a/src/schedule/schedule_info_query.zig
+++ b/src/schedule/schedule_info_query.zig
@@ -186,9 +186,13 @@ pub const ScheduleInfoQuery = struct {
             .creator_account_id = AccountId.init(0, 0, 0),
             .payer_account_id = AccountId.init(0, 0, 0),
             .scheduled_transaction_body = "",
+            .scheduled_transaction = null,
             .ledger_id = "",
             .wait_for_expiry = false,
             .memo = "",
+            .owns_transaction_body = false,
+            .owns_ledger_id = false,
+            .owns_memo = false,
             .executed_at = null,
             .deleted_at = null,
             .expiration_time = Timestamp{ .seconds = 0, .nanos = 0 },
@@ -339,13 +343,13 @@ pub const ScheduleInfoQuery = struct {
                             11 => {
                                 // signatories (repeated)
                                 const sig_bytes = try schedule_reader.readMessage();
-                                const signatory = try Key.fromProtobuf(sig_bytes, self.base.allocator);
+                                const signatory = try Key.fromProtobuf(self.base.allocator, sig_bytes);
                                 try info.signatories.append(signatory);
                             },
                             12 => {
                                 // adminKey
                                 const key_bytes = try schedule_reader.readMessage();
-                                info.admin_key = try Key.fromProtobuf(key_bytes, self.base.allocator);
+                                info.admin_key = try Key.fromProtobuf(self.base.allocator, key_bytes);
                             },
                             else => try schedule_reader.skipField(s_tag.wire_type),
                         }

--- a/src/token/abstract_token_transfer_transaction.zig
+++ b/src/token/abstract_token_transfer_transaction.zig
@@ -1,0 +1,405 @@
+// Base transaction class for token transfer operations
+// Provides common functionality for token and NFT transfers
+
+const std = @import("std");
+const Transaction = @import("../transaction/transaction.zig").Transaction;
+const TokenId = @import("../core/id.zig").TokenId;
+const AccountId = @import("../core/id.zig").AccountId;
+const NftId = @import("../core/id.zig").NftId;
+const HederaError = @import("../core/errors.zig").HederaError;
+const ProtoWriter = @import("../protobuf/writer.zig").ProtoWriter;
+const requireNotFrozen = @import("../core/errors.zig").requireNotFrozen;
+
+// Use existing TokenTransfer and NftTransfer from transfer module - NO REDUNDANCY
+const TokenTransfer = @import("../transfer/transfer_transaction.zig").TokenTransfer;
+const NftTransfer = @import("../transfer/transfer_transaction.zig").NftTransfer;
+
+// Token transfer list structure
+pub const TokenTransferList = struct {
+    token_id: TokenId,
+    expected_decimals: ?u32 = null,
+    transfers: std.ArrayList(TokenTransfer),
+    nft_transfers: std.ArrayList(NftTransfer),
+    
+    pub fn init(allocator: std.mem.Allocator, token_id: TokenId) TokenTransferList {
+        return .{
+            .token_id = token_id,
+            .expected_decimals = null,
+            .transfers = std.ArrayList(TokenTransfer).init(allocator),
+            .nft_transfers = std.ArrayList(NftTransfer).init(allocator),
+        };
+    }
+    
+    pub fn deinit(self: *TokenTransferList) void {
+        self.transfers.deinit();
+        self.nft_transfers.deinit();
+    }
+    
+    pub fn toProtobuf(self: *const TokenTransferList, allocator: std.mem.Allocator) ![]u8 {
+        var writer = ProtoWriter.init(allocator);
+        defer writer.deinit();
+        
+        // token = 1
+        const token_bytes = try self.token_id.toProtobuf(allocator);
+        defer allocator.free(token_bytes);
+        try writer.writeMessage(1, token_bytes);
+        
+        // expectedDecimals = 2
+        if (self.expected_decimals) |decimals| {
+            var decimals_writer = ProtoWriter.init(allocator);
+            defer decimals_writer.deinit();
+            try decimals_writer.writeUint32(1, decimals);
+            const decimals_bytes = try decimals_writer.toOwnedSlice();
+            defer allocator.free(decimals_bytes);
+            try writer.writeMessage(2, decimals_bytes);
+        }
+        
+        // transfers = 3 (repeated)
+        for (self.transfers.items) |transfer| {
+            const transfer_bytes = try transfer.toProtobuf(allocator);
+            defer allocator.free(transfer_bytes);
+            try writer.writeMessage(3, transfer_bytes);
+        }
+        
+        // nftTransfers = 4 (repeated)
+        for (self.nft_transfers.items) |nft| {
+            const nft_bytes = try nft.toProtobuf(allocator);
+            defer allocator.free(nft_bytes);
+            try writer.writeMessage(4, nft_bytes);
+        }
+        
+        return writer.toOwnedSlice();
+    }
+};
+
+// Base class for token transfer transactions
+pub const AbstractTokenTransferTransaction = struct {
+    base: Transaction,
+    token_transfers: std.ArrayList(TokenTransfer),
+    nft_transfers: std.ArrayList(NftTransfer),
+    
+    const Self = @This();
+    
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return Self{
+            .base = Transaction.init(allocator),
+            .token_transfers = std.ArrayList(TokenTransfer).init(allocator),
+            .nft_transfers = std.ArrayList(NftTransfer).init(allocator),
+        };
+    }
+    
+    pub fn deinit(self: *Self) void {
+        self.token_transfers.deinit();
+        self.nft_transfers.deinit();
+        self.base.deinit();
+    }
+    
+    // Add a token transfer
+    pub fn addTokenTransfer(self: *Self, token_id: TokenId, account_id: AccountId, amount: i64) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Check if transfer already exists and merge amounts
+        for (self.token_transfers.items) |*transfer| {
+            if (transfer.token_id.equals(token_id) and transfer.account_id.equals(account_id)) {
+                transfer.amount += amount;
+                return self;
+            }
+        }
+        
+        // Add new transfer
+        try self.token_transfers.append(.{
+            .token_id = token_id,
+            .account_id = account_id,
+            .amount = amount,
+            .is_approved = false,
+            .expected_decimals = null,
+        });
+        
+        return self;
+    }
+    
+    // Add an approved token transfer
+    pub fn addApprovedTokenTransfer(self: *Self, token_id: TokenId, account_id: AccountId, amount: i64) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Check if transfer already exists and merge amounts
+        for (self.token_transfers.items) |*transfer| {
+            if (transfer.token_id.equals(token_id) and transfer.account_id.equals(account_id)) {
+                transfer.amount += amount;
+                transfer.is_approved = true;
+                return self;
+            }
+        }
+        
+        // Add new approved transfer
+        try self.token_transfers.append(.{
+            .token_id = token_id,
+            .account_id = account_id,
+            .amount = amount,
+            .is_approved = true,
+            .expected_decimals = null,
+        });
+        
+        return self;
+    }
+    
+    // Add a token transfer with expected decimals
+    pub fn addTokenTransferWithDecimals(self: *Self, token_id: TokenId, account_id: AccountId, amount: i64, decimals: u32) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Check if transfer already exists
+        for (self.token_transfers.items) |*transfer| {
+            if (transfer.token_id.equals(token_id)) {
+                // Verify decimals match
+                if (transfer.expected_decimals) |existing_decimals| {
+                    if (existing_decimals != decimals) {
+                        return HederaError.InvalidParameter;
+                    }
+                } else {
+                    transfer.expected_decimals = decimals;
+                }
+                
+                if (transfer.account_id.equals(account_id)) {
+                    transfer.amount += amount;
+                    return self;
+                }
+            }
+        }
+        
+        // Add new transfer with decimals
+        try self.token_transfers.append(.{
+            .token_id = token_id,
+            .account_id = account_id,
+            .amount = amount,
+            .is_approved = false,
+            .expected_decimals = decimals,
+        });
+        
+        return self;
+    }
+    
+    // Add an NFT transfer
+    pub fn addNftTransfer(self: *Self, nft_id: NftId, sender: AccountId, receiver: AccountId) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Check if NFT transfer already exists and update
+        for (self.nft_transfers.items) |*transfer| {
+            if (transfer.nft_id.equals(nft_id)) {
+                transfer.sender_account_id = sender;
+                transfer.receiver_account_id = receiver;
+                return self;
+            }
+        }
+        
+        // Add new NFT transfer  
+        try self.nft_transfers.append(NftTransfer.init(nft_id, sender, receiver));
+        
+        return self;
+    }
+    
+    // Add an approved NFT transfer
+    pub fn addApprovedNftTransfer(self: *Self, nft_id: NftId, sender: AccountId, receiver: AccountId) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Check if NFT transfer already exists and update
+        for (self.nft_transfers.items) |*transfer| {
+            if (transfer.nft_id.equals(nft_id)) {
+                transfer.sender_account_id = sender;
+                transfer.receiver_account_id = receiver;
+                transfer.is_approved = true;
+                return self;
+            }
+        }
+        
+        // Add new approved NFT transfer
+        try self.nft_transfers.append(NftTransfer.initApproved(nft_id, sender, receiver));
+        
+        return self;
+    }
+    
+    // Get token transfers
+    pub fn getTokenTransfers(self: *const Self) []const TokenTransfer {
+        return self.token_transfers.items;
+    }
+    
+    // Get NFT transfers
+    pub fn getNftTransfers(self: *const Self) []const NftTransfer {
+        return self.nft_transfers.items;
+    }
+    
+    // Clear all token transfers
+    pub fn clearTokenTransfers(self: *Self) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        self.token_transfers.clearRetainingCapacity();
+        return self;
+    }
+    
+    // Clear all NFT transfers
+    pub fn clearNftTransfers(self: *Self) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        self.nft_transfers.clearRetainingCapacity();
+        return self;
+    }
+    
+    // Build token transfer lists for protobuf
+    pub fn buildTokenTransferLists(self: *Self, allocator: std.mem.Allocator) !std.ArrayList(TokenTransferList) {
+        var lists = std.ArrayList(TokenTransferList).init(allocator);
+        errdefer {
+            for (lists.items) |*list| {
+                list.deinit();
+            }
+            lists.deinit();
+        }
+        
+        // Sort token transfers by token ID and account ID
+        std.mem.sort(TokenTransfer, self.token_transfers.items, {}, compareTokenTransfers);
+        
+        // Sort NFT transfers
+        std.mem.sort(NftTransfer, self.nft_transfers.items, {}, compareNftTransfers);
+        
+        // Build transfer lists grouped by token ID
+        var i: usize = 0;
+        var j: usize = 0;
+        
+        while (i < self.token_transfers.items.len or j < self.nft_transfers.items.len) {
+            if (i < self.token_transfers.items.len and j < self.nft_transfers.items.len) {
+                const token_transfer = self.token_transfers.items[i];
+                const nft_transfer = self.nft_transfers.items[j];
+                
+                // Check if we can add to existing list
+                if (lists.items.len > 0) {
+                    var last = &lists.items[lists.items.len - 1];
+                    
+                    if (last.token_id.equals(token_transfer.token_id)) {
+                        try last.transfers.append(token_transfer);
+                        i += 1;
+                        continue;
+                    }
+                    
+                    if (last.token_id.equals(nft_transfer.nft_id.token_id)) {
+                        try last.nft_transfers.append(nft_transfer);
+                        j += 1;
+                        continue;
+                    }
+                }
+                
+                // Create new list
+                const cmp = compareTokenIds(token_transfer.token_id, nft_transfer.nft_id.token_id);
+                if (cmp == 0) {
+                    var list = TokenTransferList.init(allocator, token_transfer.token_id);
+                    list.expected_decimals = token_transfer.expected_decimals;
+                    try list.transfers.append(token_transfer);
+                    try list.nft_transfers.append(nft_transfer);
+                    try lists.append(list);
+                    i += 1;
+                    j += 1;
+                } else if (cmp < 0) {
+                    var list = TokenTransferList.init(allocator, token_transfer.token_id);
+                    list.expected_decimals = token_transfer.expected_decimals;
+                    try list.transfers.append(token_transfer);
+                    try lists.append(list);
+                    i += 1;
+                } else {
+                    var list = TokenTransferList.init(allocator, nft_transfer.nft_id.token_id);
+                    try list.nft_transfers.append(nft_transfer);
+                    try lists.append(list);
+                    j += 1;
+                }
+            } else if (i < self.token_transfers.items.len) {
+                const token_transfer = self.token_transfers.items[i];
+                
+                // Check if we can add to existing list
+                var found = false;
+                for (lists.items) |*list| {
+                    if (list.token_id.equals(token_transfer.token_id)) {
+                        try list.transfers.append(token_transfer);
+                        found = true;
+                        break;
+                    }
+                }
+                
+                if (!found) {
+                    var list = TokenTransferList.init(allocator, token_transfer.token_id);
+                    list.expected_decimals = token_transfer.expected_decimals;
+                    try list.transfers.append(token_transfer);
+                    try lists.append(list);
+                }
+                
+                i += 1;
+            } else if (j < self.nft_transfers.items.len) {
+                const nft_transfer = self.nft_transfers.items[j];
+                
+                // Check if we can add to existing list
+                var found = false;
+                for (lists.items) |*list| {
+                    if (list.token_id.equals(nft_transfer.nft_id.token_id)) {
+                        try list.nft_transfers.append(nft_transfer);
+                        found = true;
+                        break;
+                    }
+                }
+                
+                if (!found) {
+                    var list = TokenTransferList.init(allocator, nft_transfer.nft_id.token_id);
+                    try list.nft_transfers.append(nft_transfer);
+                    try lists.append(list);
+                }
+                
+                j += 1;
+            }
+        }
+        
+        return lists;
+    }
+    
+    // Comparison functions for sorting
+    fn compareTokenTransfers(context: void, a: TokenTransfer, b: TokenTransfer) bool {
+        _ = context;
+        const token_cmp = compareTokenIds(a.token_id, b.token_id);
+        if (token_cmp != 0) {
+            return token_cmp < 0;
+        }
+        return compareAccountIds(a.account_id, b.account_id) < 0;
+    }
+    
+    fn compareNftTransfers(context: void, a: NftTransfer, b: NftTransfer) bool {
+        _ = context;
+        const sender_cmp = compareAccountIds(a.sender_account_id, b.sender_account_id);
+        if (sender_cmp != 0) {
+            return sender_cmp < 0;
+        }
+        
+        const receiver_cmp = compareAccountIds(a.receiver_account_id, b.receiver_account_id);
+        if (receiver_cmp != 0) {
+            return receiver_cmp < 0;
+        }
+        
+        return a.nft_id.serial_number < b.nft_id.serial_number;
+    }
+    
+    fn compareTokenIds(a: TokenId, b: TokenId) i32 {
+        if (a.shard != b.shard) {
+            return if (a.shard < b.shard) -1 else 1;
+        }
+        if (a.realm != b.realm) {
+            return if (a.realm < b.realm) -1 else 1;
+        }
+        if (a.token != b.token) {
+            return if (a.token < b.token) -1 else 1;
+        }
+        return 0;
+    }
+    
+    fn compareAccountIds(a: AccountId, b: AccountId) i32 {
+        if (a.shard != b.shard) {
+            return if (a.shard < b.shard) -1 else 1;
+        }
+        if (a.realm != b.realm) {
+            return if (a.realm < b.realm) -1 else 1;
+        }
+        if (a.account != b.account) {
+            return if (a.account < b.account) -1 else 1;
+        }
+        return 0;
+    }
+};

--- a/src/token/airdrop_pending_transaction.zig
+++ b/src/token/airdrop_pending_transaction.zig
@@ -1,0 +1,202 @@
+// Transaction to manage pending airdrops
+// Allows operations on airdrops that are waiting to be claimed
+
+const std = @import("std");
+const Transaction = @import("../transaction/transaction.zig").Transaction;
+const TransactionResponse = @import("../transaction/transaction_response.zig").TransactionResponse;
+const PendingAirdropId = @import("pending_airdrop_id.zig").PendingAirdropId;
+const ProtoWriter = @import("../protobuf/writer.zig").ProtoWriter;
+const AccountId = @import("../core/id.zig").AccountId;
+const HederaError = @import("../core/errors.zig").HederaError;
+const requireNotFrozen = @import("../core/errors.zig").requireNotFrozen;
+
+// Transaction for managing pending airdrops
+pub const AirdropPendingTransaction = struct {
+    base: Transaction,
+    pending_airdrop_ids: std.ArrayList(PendingAirdropId),
+    
+    const Self = @This();
+    
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return Self{
+            .base = Transaction.init(allocator),
+            .pending_airdrop_ids = std.ArrayList(PendingAirdropId).init(allocator),
+        };
+    }
+    
+    pub fn deinit(self: *Self) void {
+        self.pending_airdrop_ids.deinit();
+        self.base.deinit();
+    }
+    
+    // Add a pending airdrop ID to the transaction
+    pub fn addPendingAirdropId(self: *Self, pending_airdrop_id: PendingAirdropId) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        try pending_airdrop_id.validate();
+        try self.pending_airdrop_ids.append(pending_airdrop_id);
+        return self;
+    }
+    
+    // Set multiple pending airdrop IDs
+    pub fn setPendingAirdropIds(self: *Self, pending_airdrop_ids: []const PendingAirdropId) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        
+        // Clear existing
+        self.pending_airdrop_ids.clearRetainingCapacity();
+        
+        // Validate and add all
+        for (pending_airdrop_ids) |id| {
+            try id.validate();
+            try self.pending_airdrop_ids.append(id);
+        }
+        
+        return self;
+    }
+    
+    // Get the list of pending airdrop IDs
+    pub fn getPendingAirdropIds(self: *const Self) []const PendingAirdropId {
+        return self.pending_airdrop_ids.items;
+    }
+    
+    // Clear all pending airdrop IDs
+    pub fn clearPendingAirdropIds(self: *Self) HederaError!*Self {
+        try requireNotFrozen(self.base.frozen);
+        self.pending_airdrop_ids.clearRetainingCapacity();
+        return self;
+    }
+    
+    // Build transaction body for a specific node
+    pub fn buildTransactionBodyForNode(self: *Self, node: AccountId) ![]u8 {
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        // Build TransactionBody
+        
+        // transactionID = 1
+        if (self.base.transaction_id) |tx_id| {
+            var tx_id_writer = ProtoWriter.init(self.base.allocator);
+            defer tx_id_writer.deinit();
+            
+            // validStart
+            var timestamp_writer = ProtoWriter.init(self.base.allocator);
+            defer timestamp_writer.deinit();
+            try timestamp_writer.writeInt64(1, tx_id.valid_start.seconds);
+            try timestamp_writer.writeInt32(2, tx_id.valid_start.nanos);
+            const timestamp_bytes = try timestamp_writer.toOwnedSlice();
+            defer self.base.allocator.free(timestamp_bytes);
+            try tx_id_writer.writeMessage(1, timestamp_bytes);
+            
+            // accountID
+            var account_writer = ProtoWriter.init(self.base.allocator);
+            defer account_writer.deinit();
+            try account_writer.writeInt64(1, @intCast(tx_id.account_id.shard));
+            try account_writer.writeInt64(2, @intCast(tx_id.account_id.realm));
+            try account_writer.writeInt64(3, @intCast(tx_id.account_id.account));
+            const account_bytes = try account_writer.toOwnedSlice();
+            defer self.base.allocator.free(account_bytes);
+            try tx_id_writer.writeMessage(2, account_bytes);
+            
+            const tx_id_bytes = try tx_id_writer.toOwnedSlice();
+            defer self.base.allocator.free(tx_id_bytes);
+            try writer.writeMessage(1, tx_id_bytes);
+        }
+        
+        // nodeAccountID = 2
+        var node_writer = ProtoWriter.init(self.base.allocator);
+        defer node_writer.deinit();
+        try node_writer.writeInt64(1, @intCast(node.shard));
+        try node_writer.writeInt64(2, @intCast(node.realm));
+        try node_writer.writeInt64(3, @intCast(node.account));
+        const node_bytes = try node_writer.toOwnedSlice();
+        defer self.base.allocator.free(node_bytes);
+        try writer.writeMessage(2, node_bytes);
+        
+        // transactionFee = 3
+        if (self.base.max_transaction_fee) |fee| {
+            try writer.writeUint64(3, @intCast(fee.toTinybars()));
+        }
+        
+        // transactionValidDuration = 4
+        var duration_writer = ProtoWriter.init(self.base.allocator);
+        defer duration_writer.deinit();
+        try duration_writer.writeInt64(1, self.base.transaction_valid_duration.seconds);
+        const duration_bytes = try duration_writer.toOwnedSlice();
+        defer self.base.allocator.free(duration_bytes);
+        try writer.writeMessage(4, duration_bytes);
+        
+        // memo = 5
+        if (self.base.transaction_memo.len > 0) {
+            try writer.writeStringField(5, self.base.transaction_memo);
+        }
+        
+        // tokenUpdateNfts = 54 (field number for pending airdrop operations)
+        const airdrop_body = try self.buildAirdropPendingBody();
+        defer self.base.allocator.free(airdrop_body);
+        try writer.writeMessage(54, airdrop_body);
+        
+        return writer.toOwnedSlice() catch HederaError.SerializationFailed;
+    }
+    
+    // Build the airdrop pending transaction body
+    fn buildAirdropPendingBody(self: *Self) ![]u8 {
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        // pendingAirdropIds = 1 (repeated field)
+        for (self.pending_airdrop_ids.items) |pending_id| {
+            const id_bytes = try pending_id.toProtobuf(self.base.allocator);
+            defer self.base.allocator.free(id_bytes);
+            try writer.writeMessage(1, id_bytes);
+        }
+        
+        return writer.toOwnedSlice() catch HederaError.SerializationFailed;
+    }
+    
+    // Freeze the transaction
+    pub fn freeze(self: *Self) HederaError!*Self {
+        // Validate required fields
+        if (self.pending_airdrop_ids.items.len == 0) {
+            return HederaError.InvalidParameter;
+        }
+        
+        self.base.frozen = true;
+        return self;
+    }
+    
+    // Freeze with client
+    pub fn freezeWith(self: *Self, client: anytype) HederaError!*Self {
+        // Validate required fields
+        if (self.pending_airdrop_ids.items.len == 0) {
+            return HederaError.InvalidParameter;
+        }
+        
+        _ = self.base.freezeWith(client) catch return HederaError.TransactionFrozen;
+        return self;
+    }
+    
+    // Sign the transaction
+    pub fn sign(self: *Self, private_key: anytype) HederaError!*Self {
+        _ = self.base.sign(private_key) catch return HederaError.TransactionFrozen;
+        return self;
+    }
+    
+    // Execute transaction
+    pub fn execute(self: *Self, client: anytype) !TransactionResponse {
+        // Validate required fields
+        if (self.pending_airdrop_ids.items.len == 0) {
+            return HederaError.InvalidParameter;
+        }
+        
+        // Override base buildTransactionBodyForNode
+        self.base.buildTransactionBodyForNode = buildTransactionBodyForNodeWrapper;
+        
+        // Execute through base transaction
+        return self.base.execute(client);
+    }
+    
+    // Wrapper function for Transaction base class function pointer
+    pub fn buildTransactionBodyForNodeWrapper(transaction: *Transaction, node: AccountId) anyerror![]u8 {
+        const self = @as(*AirdropPendingTransaction, @fieldParentPtr("base", transaction));
+        return self.buildTransactionBodyForNode(node);
+    }
+};

--- a/src/token/custom_fee.zig
+++ b/src/token/custom_fee.zig
@@ -132,21 +132,25 @@ pub const CustomFee = union(enum) {
     pub fn fromProtobuf(data: []const u8, allocator: std.mem.Allocator) !CustomFee {
         var reader = ProtoReader.init(data);
 
-        while (try reader.next()) |field| {
-            switch (field.number) {
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            switch (tag.field_number) {
                 1 => {
-                    const fixed_fee = try CustomFixedFee.fromProtobuf(field.data, allocator);
+                    const fixed_fee_data = try reader.readMessage();
+                    const fixed_fee = try CustomFixedFee.fromProtobuf(fixed_fee_data, allocator);
                     return CustomFee{ .fixed = fixed_fee };
                 },
                 2 => {
-                    const fractional_fee = try CustomFractionalFee.fromProtobuf(field.data, allocator);
+                    const fractional_fee_data = try reader.readMessage();
+                    const fractional_fee = try CustomFractionalFee.fromProtobuf(fractional_fee_data, allocator);
                     return CustomFee{ .fractional = fractional_fee };
                 },
                 3 => {
-                    const royalty_fee = try CustomRoyaltyFee.fromProtobuf(field.data, allocator);
+                    const royalty_fee_data = try reader.readMessage();
+                    const royalty_fee = try CustomRoyaltyFee.fromProtobuf(royalty_fee_data, allocator);
                     return CustomFee{ .royalty = royalty_fee };
                 },
-                else => {},
+                else => try reader.skipField(tag.wire_type),
             }
         }
 

--- a/src/token/pending_airdrop_id.zig
+++ b/src/token/pending_airdrop_id.zig
@@ -1,0 +1,218 @@
+// Identifier for a pending airdrop in the Hedera network
+// Tracks pending token or NFT airdrops with sender, receiver, and token information
+
+const std = @import("std");
+const AccountId = @import("../core/id.zig").AccountId;
+const TokenId = @import("../core/id.zig").TokenId;
+const NftId = @import("../core/id.zig").NftId;
+const ProtoWriter = @import("../protobuf/writer.zig").ProtoWriter;
+const ProtoReader = @import("../protobuf/reader.zig").ProtoReader;
+const HederaError = @import("../core/errors.zig").HederaError;
+
+// Represents an identifier for a pending airdrop
+pub const PendingAirdropId = struct {
+    sender_id: ?AccountId = null,
+    receiver_id: ?AccountId = null,
+    token_id: ?TokenId = null,
+    nft_id: ?NftId = null,
+    
+    const Self = @This();
+    
+    pub fn init() Self {
+        return Self{};
+    }
+    
+    // Set the sender account ID
+    pub fn setSenderId(self: *Self, sender_id: AccountId) *Self {
+        self.sender_id = sender_id;
+        return self;
+    }
+    
+    // Get the sender account ID
+    pub fn getSenderId(self: *const Self) ?AccountId {
+        return self.sender_id;
+    }
+    
+    // Set the receiver account ID
+    pub fn setReceiverId(self: *Self, receiver_id: AccountId) *Self {
+        self.receiver_id = receiver_id;
+        return self;
+    }
+    
+    // Get the receiver account ID
+    pub fn getReceiverId(self: *const Self) ?AccountId {
+        return self.receiver_id;
+    }
+    
+    // Set the fungible token ID
+    pub fn setTokenId(self: *Self, token_id: TokenId) *Self {
+        self.token_id = token_id;
+        self.nft_id = null; // Clear NFT ID when setting token ID
+        return self;
+    }
+    
+    // Get the fungible token ID
+    pub fn getTokenId(self: *const Self) ?TokenId {
+        return self.token_id;
+    }
+    
+    // Set the NFT ID
+    pub fn setNftId(self: *Self, nft_id: NftId) *Self {
+        self.nft_id = nft_id;
+        self.token_id = null; // Clear token ID when setting NFT ID
+        return self;
+    }
+    
+    // Get the NFT ID
+    pub fn getNftId(self: *const Self) ?NftId {
+        return self.nft_id;
+    }
+    
+    // Validate that the pending airdrop ID has required fields
+    pub fn validate(self: *const Self) HederaError!void {
+        if (self.sender_id == null) {
+            return HederaError.InvalidParameter;
+        }
+        if (self.receiver_id == null) {
+            return HederaError.InvalidParameter;
+        }
+        if (self.token_id == null and self.nft_id == null) {
+            return HederaError.InvalidParameter;
+        }
+        if (self.token_id != null and self.nft_id != null) {
+            return HederaError.InvalidParameter;
+        }
+    }
+    
+    // Convert to protobuf bytes
+    pub fn toProtobuf(self: *const Self, allocator: std.mem.Allocator) ![]u8 {
+        var writer = ProtoWriter.init(allocator);
+        defer writer.deinit();
+        
+        // senderId = 1
+        if (self.sender_id) |sender| {
+            const sender_bytes = try sender.toProtobuf(allocator);
+            defer allocator.free(sender_bytes);
+            try writer.writeMessage(1, sender_bytes);
+        }
+        
+        // receiverId = 2
+        if (self.receiver_id) |receiver| {
+            const receiver_bytes = try receiver.toProtobuf(allocator);
+            defer allocator.free(receiver_bytes);
+            try writer.writeMessage(2, receiver_bytes);
+        }
+        
+        // fungibleTokenType = 3 or nonFungibleToken = 4
+        if (self.token_id) |token| {
+            const token_bytes = try token.toProtobuf(allocator);
+            defer allocator.free(token_bytes);
+            try writer.writeMessage(3, token_bytes);
+        } else if (self.nft_id) |nft| {
+            var nft_writer = ProtoWriter.init(allocator);
+            defer nft_writer.deinit();
+            
+            // tokenId
+            const token_bytes = try nft.token_id.toProtobuf(allocator);
+            defer allocator.free(token_bytes);
+            try nft_writer.writeMessage(1, token_bytes);
+            
+            // serialNumber
+            try nft_writer.writeInt64(2, @intCast(nft.serial_number));
+            
+            const nft_bytes = try nft_writer.toOwnedSlice();
+            defer allocator.free(nft_bytes);
+            try writer.writeMessage(4, nft_bytes);
+        }
+        
+        return writer.toOwnedSlice();
+    }
+    
+    // Parse from protobuf bytes
+    pub fn fromProtobuf(allocator: std.mem.Allocator, bytes: []const u8) !Self {
+        var result = Self{};
+        
+        if (bytes.len == 0) {
+            return result;
+        }
+        
+        var reader = ProtoReader.init(bytes);
+        
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            
+            switch (tag.field_number) {
+                1 => {
+                    // senderId
+                    const sender_bytes = try reader.readBytes();
+                    result.sender_id = try AccountId.fromProtobuf(allocator, sender_bytes);
+                },
+                2 => {
+                    // receiverId
+                    const receiver_bytes = try reader.readBytes();
+                    result.receiver_id = try AccountId.fromProtobuf(allocator, receiver_bytes);
+                },
+                3 => {
+                    // fungibleTokenType
+                    const token_bytes = try reader.readBytes();
+                    result.token_id = try TokenId.fromProtobuf(allocator, token_bytes);
+                },
+                4 => {
+                    // nonFungibleToken
+                    const nft_bytes = try reader.readBytes();
+                    var nft_reader = ProtoReader.init(nft_bytes);
+                    
+                    var token_id: ?TokenId = null;
+                    var serial: u64 = 0;
+                    
+                    while (nft_reader.hasMore()) {
+                        const nft_tag = try nft_reader.readTag();
+                        
+                        switch (nft_tag.field_number) {
+                            1 => {
+                                const token_bytes_inner = try nft_reader.readBytes();
+                                token_id = try TokenId.fromProtobuf(allocator, token_bytes_inner);
+                            },
+                            2 => {
+                                serial = @intCast(try nft_reader.readInt64());
+                            },
+                            else => try nft_reader.skipField(nft_tag.wire_type),
+                        }
+                    }
+                    
+                    if (token_id) |tid| {
+                        result.nft_id = NftId.init(tid, serial);
+                    }
+                },
+                else => try reader.skipField(tag.wire_type),
+            }
+        }
+        
+        return result;
+    }
+    
+    // Check equality
+    pub fn equals(self: Self, other: Self) bool {
+        const sender_match = if (self.sender_id != null and other.sender_id != null)
+            self.sender_id.?.equals(other.sender_id.?)
+        else
+            self.sender_id == null and other.sender_id == null;
+            
+        const receiver_match = if (self.receiver_id != null and other.receiver_id != null)
+            self.receiver_id.?.equals(other.receiver_id.?)
+        else
+            self.receiver_id == null and other.receiver_id == null;
+            
+        const token_match = if (self.token_id != null and other.token_id != null)
+            self.token_id.?.equals(other.token_id.?)
+        else
+            self.token_id == null and other.token_id == null;
+            
+        const nft_match = if (self.nft_id != null and other.nft_id != null)
+            self.nft_id.?.equals(other.nft_id.?)
+        else
+            self.nft_id == null and other.nft_id == null;
+            
+        return sender_match and receiver_match and token_match and nft_match;
+    }
+};

--- a/src/token/token_airdrop_transaction.zig
+++ b/src/token/token_airdrop_transaction.zig
@@ -84,8 +84,8 @@ pub const TokenAirdropTransaction = struct {
     }
     
     // Freeze the transaction
-    pub fn freezeWith(self: *TokenAirdropTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenAirdropTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     // Execute the transaction

--- a/src/token/token_burn.zig
+++ b/src/token/token_burn.zig
@@ -140,8 +140,8 @@ pub const TokenBurnTransaction = struct {
     }
 
     // Freeze the transaction with client
-    pub fn freezeWith(self: *TokenBurnTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenBurnTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     // Sign the transaction

--- a/src/token/token_dissociate.zig
+++ b/src/token/token_dissociate.zig
@@ -91,8 +91,13 @@ pub const TokenDissociateTransaction = struct {
     }
     
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenDissociateTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenDissociateTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
+    }
+    
+    // Sign the transaction with a private key
+    pub fn sign(self: *TokenDissociateTransaction, private_key: anytype) !void {
+        _ = try self.base.sign(private_key);
     }
     
     // Execute the transaction

--- a/src/token/token_freeze.zig
+++ b/src/token/token_freeze.zig
@@ -52,8 +52,8 @@ pub const TokenFreezeTransaction = struct {
     }
 
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenFreezeTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenFreezeTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     // Execute the transaction

--- a/src/token/token_info_query.zig
+++ b/src/token/token_info_query.zig
@@ -785,7 +785,7 @@ pub const TokenInfoQuery = struct {
                             21 => {
                                 // customFees (repeated)
                                 const fee_bytes = try token_reader.readMessage();
-                                const custom_fee = try CustomFee.decode(fee_bytes, self.base.allocator);
+                                const custom_fee = try CustomFee.fromProtobuf(fee_bytes, self.base.allocator);
                                 try info.custom_fees.append(custom_fee);
                             },
                             22 => {

--- a/src/token/token_mint.zig
+++ b/src/token/token_mint.zig
@@ -121,8 +121,8 @@ pub const TokenMintTransaction = struct {
     }
 
     // Freeze the transaction with client
-    pub fn freezeWith(self: *TokenMintTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenMintTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     // Execute the transaction

--- a/src/token/token_pause.zig
+++ b/src/token/token_pause.zig
@@ -38,8 +38,8 @@ pub const TokenPauseTransaction = struct {
     }
 
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenPauseTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenPauseTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     // Execute the transaction

--- a/src/token/token_reject_transaction.zig
+++ b/src/token/token_reject_transaction.zig
@@ -94,8 +94,8 @@ pub const TokenRejectTransaction = struct {
     }
     
     // Freeze the transaction
-    pub fn freezeWith(self: *TokenRejectTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenRejectTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     // Execute the transaction

--- a/src/token/token_unfreeze.zig
+++ b/src/token/token_unfreeze.zig
@@ -52,8 +52,8 @@ pub const TokenUnfreezeTransaction = struct {
     }
 
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenUnfreezeTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenUnfreezeTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
 
     // Execute the transaction

--- a/src/token/token_unpause.zig
+++ b/src/token/token_unpause.zig
@@ -38,8 +38,8 @@ pub const TokenUnpauseTransaction = struct {
     }
     
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenUnpauseTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenUnpauseTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     // Execute the transaction

--- a/src/token/token_wipe.zig
+++ b/src/token/token_wipe.zig
@@ -154,8 +154,8 @@ pub const TokenWipeTransaction = struct {
     }
     
     // Freeze the transaction with client for execution
-    pub fn freezeWith(self: *TokenWipeTransaction, client: *Client) !void {
-        try self.base.freezeWith(client);
+    pub fn freezeWith(self: *TokenWipeTransaction, client: *Client) !*Transaction {
+        return try self.base.freezeWith(client);
     }
     
     // Execute the transaction

--- a/src/topic/topic_create.zig
+++ b/src/topic/topic_create.zig
@@ -25,8 +25,7 @@ pub const CustomFixedFee = struct {
 
 // TopicCreateTransaction creates a new consensus service topic
 pub const TopicCreateTransaction = struct {
-    allocator: std.mem.Allocator,
-    transaction: Transaction,
+    base: Transaction,
     admin_key: ?Key,
     submit_key: ?Key,
     fee_schedule_key: ?Key,
@@ -37,39 +36,94 @@ pub const TopicCreateTransaction = struct {
     auto_renew_account_id: ?AccountId,
     
     pub fn init(allocator: std.mem.Allocator) !*TopicCreateTransaction {
-        var self = try allocator.create(TopicCreateTransaction);
-        self.* = TopicCreateTransaction{
-            .allocator = allocator,
-            .transaction = Transaction.init(allocator),
+        var transaction = try allocator.create(TopicCreateTransaction);
+        transaction.* = TopicCreateTransaction{
+            .base = Transaction.init(allocator),
             .admin_key = null,
             .submit_key = null,
             .fee_schedule_key = null,
             .fee_exempt_keys = std.ArrayList(Key).init(allocator),
             .custom_fees = std.ArrayList(*CustomFixedFee).init(allocator),
             .memo = "",
-            .auto_renew_period = Duration{ .seconds = 7890000, .nanos = 0 },
+            .auto_renew_period = Duration{ .seconds = 7776000, .nanos = 0 }, // 90 days
             .auto_renew_account_id = null,
         };
         
-        // Set default auto renew period and max transaction fee
-        _ = self.setAutoRenewPeriod(Duration{ .seconds = 7890000, .nanos = 0 }) catch {};
-        _ = self.transaction.setMaxTransactionFee(Hbar.fromTinybars(2500000000) catch unreachable) catch {}; // 25 Hbar
+        transaction.base.max_transaction_fee = Hbar.fromTinybars(2500000000) catch Hbar.zero(); // 25 Hbar
+        transaction.base.buildTransactionBodyForNode = buildTransactionBodyForNode;
+        transaction.base.grpc_service_name = "proto.ConsensusService";
+        transaction.base.grpc_method_name = "createTopic";
         
-        return self;
+        return transaction;
+    }
+    
+    fn buildTransactionBodyForNode(base_tx: *Transaction, _: AccountId) anyerror![]u8 {
+        const self: *TopicCreateTransaction = @fieldParentPtr("base", base_tx);
+        return self.buildTransactionBody();
+    }
+    
+    pub fn buildTransactionBody(self: *TopicCreateTransaction) ![]u8 {
+        const ProtoWriter = @import("../protobuf/encoding.zig").ProtoWriter;
+        
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
+        
+        var create_writer = ProtoWriter.init(self.base.allocator);
+        defer create_writer.deinit();
+        
+        if (self.admin_key) |key| {
+            const key_bytes = try key.toProtobuf(self.base.allocator);
+            defer self.base.allocator.free(key_bytes);
+            try create_writer.writeMessage(1, key_bytes);
+        }
+        
+        if (self.submit_key) |key| {
+            const key_bytes = try key.toProtobuf(self.base.allocator);
+            defer self.base.allocator.free(key_bytes);
+            try create_writer.writeMessage(2, key_bytes);
+        }
+        
+        var period_writer = ProtoWriter.init(self.base.allocator);
+        defer period_writer.deinit();
+        try period_writer.writeInt64(1, self.auto_renew_period.seconds);
+        const period_bytes = try period_writer.toOwnedSlice();
+        defer self.base.allocator.free(period_bytes);
+        try create_writer.writeMessage(6, period_bytes);
+        
+        if (self.auto_renew_account_id) |account| {
+            var account_writer = ProtoWriter.init(self.base.allocator);
+            defer account_writer.deinit();
+            try account_writer.writeInt64(1, @intCast(account.shard));
+            try account_writer.writeInt64(2, @intCast(account.realm));
+            try account_writer.writeInt64(3, @intCast(account.account));
+            const account_bytes = try account_writer.toOwnedSlice();
+            defer self.base.allocator.free(account_bytes);
+            try create_writer.writeMessage(7, account_bytes);
+        }
+        
+        if (self.memo.len > 0) {
+            try create_writer.writeString(3, self.memo);
+        }
+        
+        const create_bytes = try create_writer.toOwnedSlice();
+        defer self.base.allocator.free(create_bytes);
+        try writer.writeMessage(24, create_bytes);
+        
+        return writer.toOwnedSlice();
     }
     
     pub fn deinit(self: *TopicCreateTransaction) void {
+        self.base.deinit();
         self.fee_exempt_keys.deinit();
         for (self.custom_fees.items) |fee| {
-            self.allocator.destroy(fee);
+            self.base.allocator.destroy(fee);
         }
         self.custom_fees.deinit();
-        self.transaction.deinit();
+        self.base.allocator.destroy(self);
     }
     
-    // setAdminKey sets the key required to update or delete the topic
     pub fn setAdminKey(self: *TopicCreateTransaction, public_key: Key) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.admin_key = public_key;
         return self;
     }
@@ -81,7 +135,7 @@ pub const TopicCreateTransaction = struct {
     
     // setSubmitKey sets the key required for submitting messages to the topic
     pub fn setSubmitKey(self: *TopicCreateTransaction, public_key: Key) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.submit_key = public_key;
         return self;
     }
@@ -93,7 +147,7 @@ pub const TopicCreateTransaction = struct {
     
     // setFeeScheduleKey sets the key which allows updates to the new topic's fees
     pub fn setFeeScheduleKey(self: *TopicCreateTransaction, public_key: Key) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.fee_schedule_key = public_key;
         return self;
     }
@@ -105,7 +159,7 @@ pub const TopicCreateTransaction = struct {
     
     // SetFeeExemptKeys sets the keys that will be exempt from paying fees
     pub fn setFeeExemptKeys(self: *TopicCreateTransaction, keys: []const Key) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.fee_exempt_keys.clearRetainingCapacity();
         try errors.handleAppendSliceError(&self.fee_exempt_keys, keys);
         return self;
@@ -114,14 +168,14 @@ pub const TopicCreateTransaction = struct {
     
     // AddFeeExemptKey adds a key that will be exempt from paying fees
     pub fn addFeeExemptKey(self: *TopicCreateTransaction, key: Key) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         try errors.handleAppendError(&self.fee_exempt_keys, key);
         return self;
     }
     
     // ClearFeeExemptKeys removes all keys that will be exempt from paying fees
     pub fn clearFeeExemptKeys(self: *TopicCreateTransaction) HederaError!*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.fee_exempt_keys.clearRetainingCapacity();
         return self;
     }
@@ -133,7 +187,7 @@ pub const TopicCreateTransaction = struct {
     
     // SetCustomFees sets the fixed fees to assess when a message is submitted to the new topic
     pub fn setCustomFees(self: *TopicCreateTransaction, fees: []*CustomFixedFee) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         for (self.custom_fees.items) |fee| {
             self.allocator.destroy(fee);
         }
@@ -144,14 +198,14 @@ pub const TopicCreateTransaction = struct {
     
     // AddCustomFee adds a fixed fee to assess when a message is submitted to the new topic
     pub fn addCustomFee(self: *TopicCreateTransaction, fee: *CustomFixedFee) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         try errors.handleAppendError(&self.custom_fees, fee);
         return self;
     }
     
     // ClearCustomFees removes all custom fees to assess when a message is submitted to the new topic
     pub fn clearCustomFees(self: *TopicCreateTransaction) HederaError!*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         for (self.custom_fees.items) |fee| {
             self.allocator.destroy(fee);
         }
@@ -166,7 +220,7 @@ pub const TopicCreateTransaction = struct {
     
     // SetTopicMemo sets a short publicly visible memo about the topic
     pub fn setTopicMemo(self: *TopicCreateTransaction, memo: []const u8) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.memo = memo;
         return self;
     }
@@ -178,7 +232,7 @@ pub const TopicCreateTransaction = struct {
     
     // SetAutoRenewPeriod sets the initial lifetime of the topic
     pub fn setAutoRenewPeriod(self: *TopicCreateTransaction, period: Duration) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.auto_renew_period = period;
         return self;
     }
@@ -190,7 +244,7 @@ pub const TopicCreateTransaction = struct {
     
     // SetAutoRenewAccountID sets an optional account to be used at the topic's expirationTime
     pub fn setAutoRenewAccountId(self: *TopicCreateTransaction, auto_renew_account_id: AccountId) !*TopicCreateTransaction {
-        try errors.requireNotFrozen(self.transaction.frozen);
+        if (self.base.frozen) return error.TransactionFrozen;
         self.auto_renew_account_id = auto_renew_account_id;
         return self;
     }
@@ -200,9 +254,8 @@ pub const TopicCreateTransaction = struct {
         return self.auto_renew_account_id orelse AccountId{};
     }
     
-    // Execute executes the transaction
     pub fn execute(self: *TopicCreateTransaction, client: *Client) !TransactionResponse {
-        return try self.transaction.execute(client);
+        return try self.base.execute(client);
     }
     
     // Freeze prepares the transaction for execution
@@ -210,55 +263,54 @@ pub const TopicCreateTransaction = struct {
         return try self.freezeWith(null);
     }
     
-    // FreezeWith prepares the transaction for execution with a client
     pub fn freezeWith(self: *TopicCreateTransaction, client: ?*Client) !*TopicCreateTransaction {
-        try self.transaction.freezeWith(client);
+        _ = try self.base.freezeWith(client);
         return self;
     }
     
     // Sign signs the transaction
     pub fn sign(self: *TopicCreateTransaction, private_key: anytype) !*TopicCreateTransaction {
-        try self.transaction.sign(private_key);
+        try self.base.sign(private_key);
         return self;
     }
     
     // SignWith signs the transaction with a specific key
     pub fn signWith(self: *TopicCreateTransaction, public_key: anytype, private_key: anytype) *TopicCreateTransaction {
-        self.transaction.signWith(public_key, private_key);
+        self.base.signWith(public_key, private_key);
         return self;
     }
     
     // SetMaxTransactionFee sets the maximum transaction fee
     pub fn setMaxTransactionFee(self: *TopicCreateTransaction, fee: Hbar) !*TopicCreateTransaction {
-        _ = self.transaction.setMaxTransactionFee(fee);
+        _ = self.base.setMaxTransactionFee(fee);
         return self;
     }
     
     // GetMaxTransactionFee returns the maximum transaction fee
     pub fn getMaxTransactionFee(self: *TopicCreateTransaction) ?Hbar {
-        return self.transaction.getMaxTransactionFee();
+        return self.base.getMaxTransactionFee();
     }
     
     // SetTransactionMemo sets the transaction memo
     pub fn setTransactionMemo(self: *TopicCreateTransaction, memo: []const u8) !*TopicCreateTransaction {
-        _ = self.transaction.setTransactionMemo(memo) catch {};
+        _ = self.base.setTransactionMemo(memo) catch {};
         return self;
     }
     
     // GetTransactionMemo returns the transaction memo
     pub fn getTransactionMemo(self: *TopicCreateTransaction) []const u8 {
-        return self.transaction.getTransactionMemo();
+        return self.base.getTransactionMemo();
     }
     
     // SetNodeAccountIDs sets the node account IDs for this transaction
     pub fn setNodeAccountIDs(self: *TopicCreateTransaction, node_account_ids: []const AccountId) !*TopicCreateTransaction {
-        _ = self.transaction.setNodeAccountIDs(node_account_ids);
+        _ = self.base.setNodeAccountIDs(node_account_ids);
         return self;
     }
     
     // GetNodeAccountIDs returns the node account IDs for this transaction
     pub fn getNodeAccountIDs(self: *TopicCreateTransaction) []const AccountId {
-        return self.transaction.getNodeAccountIDs();
+        return self.base.getNodeAccountIDs();
     }
 };
 

--- a/src/topic/topic_delete.zig
+++ b/src/topic/topic_delete.zig
@@ -55,13 +55,13 @@ pub const TopicDeleteTransaction = struct {
     
     // FreezeWith prepares the transaction for execution with a client
     pub fn freezeWith(self: *TopicDeleteTransaction, client: ?*Client) !*TopicDeleteTransaction {
-        try self.transaction.freezeWith(client);
+        _ = try self.transaction.freezeWith(client);
         return self;
     }
     
     // Sign signs the transaction
-    pub fn sign(self: *TopicDeleteTransaction, private_key: anytype) *TopicDeleteTransaction {
-        self.transaction.sign(private_key);
+    pub fn sign(self: *TopicDeleteTransaction, private_key: anytype) !*TopicDeleteTransaction {
+        _ = try self.transaction.sign(private_key);
         return self;
     }
     

--- a/src/topic/topic_update.zig
+++ b/src/topic/topic_update.zig
@@ -46,7 +46,7 @@ pub const TopicUpdateTransaction = struct {
         };
         
         // Set default auto renew period
-        _ = self.setAutoRenewPeriod(Duration{ .seconds = 7890000, .nanos = 0 }) catch return error.InvalidParameter;
+        _ = self.setAutoRenewPeriod(Duration{ .seconds = 7776000, .nanos = 0 }) catch return error.InvalidParameter; // 90 days
         
         return self;
     }
@@ -259,13 +259,13 @@ pub const TopicUpdateTransaction = struct {
     
     // FreezeWith prepares the transaction for execution with a client
     pub fn freezeWith(self: *TopicUpdateTransaction, client: ?*Client) !*TopicUpdateTransaction {
-        try self.transaction.freezeWith(client);
+        _ = try self.transaction.freezeWith(client);
         return self;
     }
     
     // Sign signs the transaction
-    pub fn sign(self: *TopicUpdateTransaction, private_key: anytype) *TopicUpdateTransaction {
-        self.transaction.sign(private_key);
+    pub fn sign(self: *TopicUpdateTransaction, private_key: anytype) !*TopicUpdateTransaction {
+        _ = try self.transaction.sign(private_key);
         return self;
     }
     

--- a/src/transaction/transaction_receipt_query.zig
+++ b/src/transaction/transaction_receipt_query.zig
@@ -3,95 +3,142 @@
 
 const std = @import("std");
 const ProtoWriter = @import("../protobuf/writer.zig").ProtoWriter;
+const ProtoReader = @import("../protobuf/encoding.zig").ProtoReader;
 const TransactionId = @import("../core/transaction_id.zig").TransactionId;
 const AccountId = @import("../core/id.zig").AccountId;
-const TransactionReceipt = @import("transaction.zig").TransactionReceipt;
+const TransactionReceipt = @import("transaction_receipt.zig").TransactionReceipt;
 const Status = @import("../core/status.zig").Status;
+const Query = @import("../query/query.zig").Query;
+const QueryResponse = @import("../query/query.zig").QueryResponse;
+const Client = @import("../network/client.zig").Client;
+const Hbar = @import("../core/hbar.zig").Hbar;
 
 // Receipt query for fetching transaction results
 pub const TransactionReceiptQuery = struct {
-    allocator: std.mem.Allocator,
-    transaction_id: TransactionId,
-    include_duplicates: bool = false,
-    include_children: bool = false,
-    validate_status: bool = true,
+    base: Query,
+    transaction_id: ?TransactionId,
+    include_duplicates: bool,
+    include_children: bool,
+    validate_status: bool,
     
-    const Self = @This();
-    
-    pub fn init(allocator: std.mem.Allocator, transaction_id: TransactionId) Self {
-        return Self{
-            .allocator = allocator,
-            .transaction_id = transaction_id,
+    pub fn init(allocator: std.mem.Allocator) TransactionReceiptQuery {
+        var query = TransactionReceiptQuery{
+            .base = Query.init(allocator),
+            .transaction_id = null,
             .include_duplicates = false,
             .include_children = false,
             .validate_status = true,
         };
+        query.base.grpc_service_name = "proto.CryptoService";
+        query.base.grpc_method_name = "getTransactionReceipts";
+        query.base.is_payment_required = false;  // Receipt queries are free
+        return query;
+    }
+    
+    pub fn deinit(self: *TransactionReceiptQuery) void {
+        self.base.deinit();
+    }
+    
+    // Set the transaction ID
+    pub fn setTransactionId(self: *TransactionReceiptQuery, transaction_id: TransactionId) !*TransactionReceiptQuery {
+        self.transaction_id = transaction_id;
+        return self;
+    }
+    
+    // Set include duplicates flag
+    pub fn setIncludeDuplicates(self: *TransactionReceiptQuery, include: bool) !*TransactionReceiptQuery {
+        self.include_duplicates = include;
+        return self;
+    }
+    
+    // Set include children flag
+    pub fn setIncludeChildren(self: *TransactionReceiptQuery, include: bool) !*TransactionReceiptQuery {
+        self.include_children = include;
+        return self;
+    }
+    
+    // Set validate status flag
+    pub fn setValidateStatus(self: *TransactionReceiptQuery, validate: bool) !*TransactionReceiptQuery {
+        self.validate_status = validate;
+        return self;
     }
     
     // Build query protobuf
-    pub fn build(self: *Self) ![]u8 {
-        var query_writer = ProtoWriter.init(self.allocator);
-        defer query_writer.deinit();
+    pub fn buildQuery(self: *TransactionReceiptQuery) ![]u8 {
+        var writer = ProtoWriter.init(self.base.allocator);
+        defer writer.deinit();
         
-        // Build TransactionGetReceiptQuery
-        var receipt_query = ProtoWriter.init(self.allocator);
-        defer receipt_query.deinit();
+        // transactionGetReceipt = 4 (oneof query)
+        var receipt_query_writer = ProtoWriter.init(self.base.allocator);
+        defer receipt_query_writer.deinit();
         
-        // transactionID = 1
-        const tx_id_bytes = try self.encodeTransactionId();
-        defer self.allocator.free(tx_id_bytes);
-        try receipt_query.writeMessage(1, tx_id_bytes);
+        // header = 1 (inside the specific query)
+        var header_writer = ProtoWriter.init(self.base.allocator);
+        defer header_writer.deinit();
         
-        // includeDuplicates = 2
+        // payment = 1 (optional for free queries - Receipt queries are free)
+        // responseType = 2 (must be present even if 0)
+        try header_writer.writeTag(2, .Varint);
+        try header_writer.writeVarint(@as(u64, @intCast(@intFromEnum(self.base.response_type))));
+        
+        const header_bytes = try header_writer.toOwnedSlice();
+        defer self.base.allocator.free(header_bytes);
+        try receipt_query_writer.writeMessage(1, header_bytes);
+        
+        // transactionID = 2
+        if (self.transaction_id) |tx_id| {
+            const tx_id_bytes = try self.encodeTransactionId(tx_id);
+            defer self.base.allocator.free(tx_id_bytes);
+            try receipt_query_writer.writeMessage(2, tx_id_bytes);
+        }
+        
+        // includeDuplicates = 3
         if (self.include_duplicates) {
-            try receipt_query.writeBool(2, true);
+            try receipt_query_writer.writeBool(3, true);
         }
         
-        // includeChildReceipts = 3
+        // includeChildReceipts = 4
         if (self.include_children) {
-            try receipt_query.writeBool(3, true);
+            try receipt_query_writer.writeBool(4, true);
         }
         
-        const receipt_query_bytes = try receipt_query.toOwnedSlice();
-        defer self.allocator.free(receipt_query_bytes);
+        const receipt_query_bytes = try receipt_query_writer.toOwnedSlice();
+        defer self.base.allocator.free(receipt_query_bytes);
+        try writer.writeMessage(4, receipt_query_bytes);
         
-        // Wrap in Query message
-        // transactionGetReceipt = 2
-        try query_writer.writeMessage(2, receipt_query_bytes);
-        
-        return query_writer.toOwnedSlice();
+        return writer.toOwnedSlice();
     }
     
-    fn encodeTransactionId(self: *Self) ![]u8 {
-        var writer = ProtoWriter.init(self.allocator);
+    fn encodeTransactionId(self: *TransactionReceiptQuery, tx_id: TransactionId) ![]u8 {
+        var writer = ProtoWriter.init(self.base.allocator);
         defer writer.deinit();
         
         // transactionValidStart = 1
-        var timestamp_writer = ProtoWriter.init(self.allocator);
+        var timestamp_writer = ProtoWriter.init(self.base.allocator);
         defer timestamp_writer.deinit();
-        try timestamp_writer.writeInt64(1, self.transaction_id.valid_start.seconds);
-        try timestamp_writer.writeInt32(2, self.transaction_id.valid_start.nanos);
+        try timestamp_writer.writeInt64(1, tx_id.valid_start.seconds);
+        try timestamp_writer.writeInt32(2, tx_id.valid_start.nanos);
         const timestamp_bytes = try timestamp_writer.toOwnedSlice();
-        defer self.allocator.free(timestamp_bytes);
+        defer self.base.allocator.free(timestamp_bytes);
         try writer.writeMessage(1, timestamp_bytes);
         
         // accountID = 2
-        var account_writer = ProtoWriter.init(self.allocator);
+        var account_writer = ProtoWriter.init(self.base.allocator);
         defer account_writer.deinit();
-        try account_writer.writeInt64(1, @intCast(self.transaction_id.account_id.shard));
-        try account_writer.writeInt64(2, @intCast(self.transaction_id.account_id.realm));
-        try account_writer.writeInt64(3, @intCast(self.transaction_id.account_id.account));
+        try account_writer.writeInt64(1, @intCast(tx_id.account_id.shard));
+        try account_writer.writeInt64(2, @intCast(tx_id.account_id.realm));
+        try account_writer.writeInt64(3, @intCast(tx_id.account_id.account));
         const account_bytes = try account_writer.toOwnedSlice();
-        defer self.allocator.free(account_bytes);
+        defer self.base.allocator.free(account_bytes);
         try writer.writeMessage(2, account_bytes);
         
         // scheduled = 3
-        if (self.transaction_id.scheduled) {
+        if (tx_id.scheduled) {
             try writer.writeBool(3, true);
         }
         
         // nonce = 4
-        if (self.transaction_id.nonce) |nonce| {
+        if (tx_id.nonce) |nonce| {
             try writer.writeInt32(4, @intCast(nonce));
         }
         
@@ -99,71 +146,64 @@ pub const TransactionReceiptQuery = struct {
     }
     
     // Execute query on network
-    pub fn execute(self: *Self, client: anytype) !TransactionReceipt {
-        const query_bytes = try self.build();
-        defer self.allocator.free(query_bytes);
+    pub fn execute(self: *TransactionReceiptQuery, client: *Client) !TransactionReceipt {
+        if (self.transaction_id == null) {
+            return error.TransactionIdRequired;
+        }
         
-        // Submit query to network
-        const response_bytes = try client.executeReceiptQuery(query_bytes, self.transaction_id.account_id);
-        defer self.allocator.free(response_bytes);
+        // Build the query bytes directly
+        const query_bytes = try self.buildQuery();
+        defer self.base.allocator.free(query_bytes);
         
-        // Parse response
-        return self.parseResponse(response_bytes);
+        // Execute with the built bytes
+        const response = try self.base.executeWithBytes(client, query_bytes);
+        return try self.parseResponse(response);
     }
     
-    fn parseResponse(self: *Self, response_bytes: []const u8) !TransactionReceipt {
-        // Parse response to extract status
-        // Look for status field in the response
-        var status = Status.OK; // Default to OK
-        var account_id: ?AccountId = null;
+    // Parse the response
+    fn parseResponse(self: *TransactionReceiptQuery, response: QueryResponse) !TransactionReceipt {
+        // For receipt queries, we don't validate status here as the status in the receipt is what matters
         
-        // Simple parsing - look for status code
-        // Status is typically at the beginning of the receipt
-        if (response_bytes.len > 10) {
-            // Try to find SUCCESS status (22) in response
-            for (response_bytes, 0..) |byte, i| {
-                if (byte == 22 and i > 0) { // Found potential status
-                    status = Status.SUCCESS; // SUCCESS
-                    // Try to find account ID after status
-                    // Account creation puts new account ID after status
-                    if (i + 10 < response_bytes.len) {
-                        // Look for account number pattern
-                        // Account IDs are encoded as varints
-                        account_id = AccountId{
-                            .shard = 0,
-                            .realm = 0,
-                            .account = 0, // Will be parsed from actual response
-                            .alias_key = null,
-                            .alias_evm_address = null,
-                            .checksum = null,
-                        };
-                    }
-                    break;
-                }
+        var reader = ProtoReader.init(response.response_bytes);
+        var receipt = TransactionReceipt.init(self.base.allocator, Status.OK);
+        
+        // Parse TransactionGetReceiptResponse
+        while (reader.hasMore()) {
+            const tag = try reader.readTag();
+            
+            switch (tag.field_number) {
+                1 => {
+                    // header
+                    _ = try reader.readMessage();
+                },
+                2 => {
+                    // receipt
+                    const receipt_bytes = try reader.readMessage();
+                    receipt = try TransactionReceipt.fromProtobuf(self.base.allocator, receipt_bytes);
+                },
+                3 => {
+                    // duplicates
+                    const duplicate_bytes = try reader.readMessage();
+                    _ = duplicate_bytes;
+                    // Duplicates will be parsed when needed
+                },
+                4 => {
+                    // childTransactionReceipts
+                    const child_bytes = try reader.readMessage();
+                    _ = child_bytes;
+                    // Children will be parsed when needed
+                },
+                else => try reader.skipField(tag.wire_type),
             }
         }
         
-        return TransactionReceipt{
-            .status = status,
-            .exchange_rate = null,
-            .next_exchange_rate = null,
-            .topic_id = null,
-            .file_id = null,
-            .contract_id = null,
-            .account_id = account_id,
-            .token_id = null,
-            .topic_sequence_number = 0,
-            .topic_running_hash = &.{},
-            .topic_running_hash_version = 0,
-            .total_supply = 0,
-            .schedule_id = null,
-            .scheduled_transaction_id = null,
-            .serial_numbers = &.{},
-            .node_id = 0,
-            .duplicates = &.{},
-            .children = &.{},
-            .transaction_id = self.transaction_id,
-            .allocator = self.allocator,
-        };
+        // Validate status if requested
+        if (self.validate_status) {
+            if (receipt.status != .SUCCESS) {
+                return error.ReceiptStatusError;
+            }
+        }
+        
+        return receipt;
     }
 };

--- a/src/transaction/transaction_response.zig
+++ b/src/transaction/transaction_response.zig
@@ -70,7 +70,11 @@ pub const TransactionResponse = struct {
             query.deinit();
             self.allocator.destroy(query);
         }
-        return try query.execute(client);
+        // Always include child receipts for proper hollow account support
+        _ = try query.setIncludeChildren(true);
+        _ = try query.setIncludeDuplicates(true);
+        // Use executeAsync to wait for receipt to be ready
+        return try query.executeAsync(client);
     }
     
     pub fn getReceiptAsync(self: *const Self, client: *Client) !TransactionReceipt {

--- a/tck/build.zig
+++ b/tck/build.zig
@@ -1,54 +1,33 @@
 const std = @import("std");
-
 pub fn build(b: *std.Build) void {
-    // Standard target and optimization options
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    
-    // Get the hedera SDK module from parent
     const hedera_sdk = b.createModule(.{
         .root_source_file = b.path("../src/hedera.zig"),
     });
-    
-    // Create the TCK server executable
     const tck_server = b.addExecutable(.{
         .name = "tck-server",
         .root_source_file = b.path("server.zig"),
         .target = target,
         .optimize = optimize,
     });
-    
-    // Add the hedera SDK as a module
     tck_server.root_module.addImport("hedera", hedera_sdk);
-    
-    // Link required libraries
     tck_server.linkLibC();
-    
-    // Install the executable
     b.installArtifact(tck_server);
-    
-    // Create a run step
     const run_cmd = b.addRunArtifact(tck_server);
     run_cmd.step.dependOn(b.getInstallStep());
-    
-    // Allow command line arguments to be passed
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
-    
     const run_step = b.step("run", "Run the TCK server");
     run_step.dependOn(&run_cmd.step);
-    
-    // Create test step for TCK components
     const test_step = b.step("test", "Run TCK tests");
-    
     const json_rpc_test = b.addTest(.{
         .root_source_file = b.path("json_rpc.zig"),
         .target = target,
         .optimize = optimize,
     });
     json_rpc_test.root_module.addImport("hedera", hedera_sdk);
-    
     const run_json_rpc_test = b.addRunArtifact(json_rpc_test);
     test_step.dependOn(&run_json_rpc_test.step);
 }

--- a/tck/json_rpc.zig
+++ b/tck/json_rpc.zig
@@ -1,32 +1,20 @@
 const std = @import("std");
 const json = std.json;
-
-// JSON-RPC 2.0 Specification Implementation
-
 pub const JSONRPC_VERSION = "2.0";
-
-// JSON-RPC Request structure
 pub const Request = struct {
     jsonrpc: []const u8 = JSONRPC_VERSION,
     method: []const u8,
     params: ?json.Value = null,
     id: ?json.Value = null,
     parsed_json: json.Parsed(json.Value),
-    
     pub fn parse(allocator: std.mem.Allocator, data: []const u8) !Request {
         const parsed = try json.parseFromSlice(json.Value, allocator, data, .{});
-        
         const obj = parsed.value.object;
-        
-        // Validate required fields
         const jsonrpc = obj.get("jsonrpc") orelse return error.InvalidRequest;
         const method = obj.get("method") orelse return error.InvalidRequest;
-        
         if (!std.mem.eql(u8, jsonrpc.string, JSONRPC_VERSION)) {
             return error.InvalidJSONRPCVersion;
         }
-        
-        // Use references to the parsed data - no cloning needed
         return Request{
             .jsonrpc = try allocator.dupe(u8, jsonrpc.string),
             .method = try allocator.dupe(u8, method.string),
@@ -35,30 +23,24 @@ pub const Request = struct {
             .parsed_json = parsed,
         };
     }
-    
     pub fn deinit(self: *Request, allocator: std.mem.Allocator) void {
         allocator.free(self.jsonrpc);
         allocator.free(self.method);
-        // params and id are references to parsed_json, so they'll be freed when parsed_json is freed
         self.parsed_json.deinit();
     }
 };
-
-// JSON-RPC Response structure
 pub const Response = struct {
     jsonrpc: []const u8 = JSONRPC_VERSION,
     result: ?json.Value = null,
     @"error": ?Error = null,
     id: ?json.Value = null,
-    
     pub fn success(allocator: std.mem.Allocator, result: json.Value, id: ?json.Value) !Response {
-        _ = allocator; // Not used for now
+        _ = allocator; 
         return Response{
             .result = result,
             .id = id,
         };
     }
-    
     pub fn err(code: i32, message: []const u8, data: ?json.Value, id: ?json.Value) Response {
         return Response{
             .@"error" = Error{
@@ -69,9 +51,7 @@ pub const Response = struct {
             .id = id,
         };
     }
-    
     pub fn stringify(self: Response, allocator: std.mem.Allocator) ![]u8 {
-        // Format the ID - handle different JSON value types
         const id_str = if (self.id) |id| switch (id) {
             .integer => |i| try std.fmt.allocPrint(allocator, "{d}", .{i}),
             .string => |s| try std.fmt.allocPrint(allocator, "\"{s}\"", .{s}),
@@ -79,19 +59,15 @@ pub const Response = struct {
             else => try std.fmt.allocPrint(allocator, "null", .{}),
         } else try std.fmt.allocPrint(allocator, "null", .{});
         defer allocator.free(id_str);
-        
         if (self.@"error") |e| {
             return try std.fmt.allocPrint(allocator,
                 "{{\"jsonrpc\":\"{s}\",\"error\":{{\"code\":{d},\"message\":\"{s}\"}},\"id\":{s}}}",
                 .{ JSONRPC_VERSION, e.code, e.message, id_str }
             );
         } else if (self.result) |result| {
-            // Serialize the actual result
             var result_str = std.ArrayList(u8).init(allocator);
             defer result_str.deinit();
-            
             try std.json.stringify(result, .{}, result_str.writer());
-            
             return try std.fmt.allocPrint(allocator,
                 "{{\"jsonrpc\":\"{s}\",\"result\":{s},\"id\":{s}}}",
                 .{ JSONRPC_VERSION, result_str.items, id_str }
@@ -103,31 +79,23 @@ pub const Response = struct {
             );
         }
     }
-    
     pub fn deinit(self: *Response, allocator: std.mem.Allocator) void {
         _ = self;
         _ = allocator;
-        // Simplified - no complex cleanup needed for now
     }
 };
-
-// JSON-RPC Error structure
 pub const Error = struct {
     code: i32,
     message: []const u8,
     data: ?json.Value = null,
 };
-
-// Standard JSON-RPC error codes
 pub const ErrorCode = struct {
     pub const PARSE_ERROR: i32 = -32700;
     pub const INVALID_REQUEST: i32 = -32600;
     pub const METHOD_NOT_FOUND: i32 = -32601;
     pub const INVALID_PARAMS: i32 = -32602;
     pub const INTERNAL_ERROR: i32 = -32603;
-    pub const SERVER_ERROR: i32 = -32000; // to -32099 reserved for implementation
-    
-    // Hedera-specific error codes
+    pub const SERVER_ERROR: i32 = -32000; 
     pub const HEDERA_ERROR: i32 = -32001;
     pub const CLIENT_NOT_CONFIGURED: i32 = -32002;
     pub const TRANSACTION_FAILED: i32 = -32003;
@@ -135,22 +103,15 @@ pub const ErrorCode = struct {
     pub const KEY_PARSE_ERROR: i32 = -32005;
     pub const ACCOUNT_ID_PARSE_ERROR: i32 = -32006;
 };
-
-// Method names enum
 pub const Method = enum {
-    // SDK methods
     setup,
     reset,
-    
-    // Account methods
     createAccount,
     updateAccount,
     deleteAccount,
     approveAllowance,
     deleteAllowance,
     transferCrypto,
-    
-    // Token methods
     createToken,
     updateToken,
     deleteToken,
@@ -170,28 +131,36 @@ pub const Method = enum {
     airdropToken,
     cancelAirdrop,
     rejectToken,
-    
-    // File methods
     createFile,
     updateFile,
     deleteFile,
     appendFile,
-    
-    // Topic methods
     createTopic,
     updateTopic,
     deleteTopic,
     submitTopicMessage,
-    
-    // Contract methods
     createContract,
     updateContract,
     deleteContract,
     executeContract,
-    
-    // Key methods
     generateKey,
-    
+    createSchedule,
+    signSchedule,
+    deleteSchedule,
+    getScheduleInfo,
+    createNode,
+    updateNode,
+    deleteNode,
+    getAccountInfo,
+    getAccountBalance,
+    getTokenInfo,
+    getTokenBalance,
+    getFileInfo,
+    getFileContents,
+    getTopicInfo,
+    getContractInfo,
+    getTransactionRecord,
+    getTransactionReceipt,
     pub fn fromString(method: []const u8) ?Method {
         inline for (std.meta.fields(Method)) |field| {
             if (std.mem.eql(u8, field.name, method)) {
@@ -201,4 +170,3 @@ pub const Method = enum {
         return null;
     }
 };
-

--- a/tck/methods/account_service.zig
+++ b/tck/methods/account_service.zig
@@ -2,367 +2,243 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.account_service);
-
-// Create account method
 pub fn createAccount(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
-    
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.accountCreateTransaction(allocator);
     defer tx.deinit();
-    
-    // Set key if provided
     if (utils.getString(p, "key")) |key_str| {
-        // Try to parse as public key first, if that fails try private key
         if (utils.parsePublicKey(allocator, key_str)) |_public_key| {
             var public_key = _public_key;
             defer public_key.deinit(allocator);
             const key = hedera.Key.fromPublicKey(public_key);
             _ = try tx.setKey(key);
         } else |_| {
-            // If public key parsing fails, try private key
             var private_key = try utils.parsePrivateKey(allocator, key_str);
             defer private_key.deinit();
             const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
             _ = try tx.setKey(key);
         }
     }
-    
-    // Set initial balance if provided
     if (utils.getString(p, "initialBalance")) |balance_str| {
         const hbar = try utils.parseHbar(balance_str);
         _ = try tx.setInitialBalance(hbar);
     }
-    
-    // Set receiver signature required if provided
     if (utils.getBool(p, "receiverSignatureRequired")) |required| {
         _ = try tx.setReceiverSignatureRequired(required);
     }
-    
-    // Set max automatic token associations if provided
     if (utils.getInt(p, "maxAutomaticTokenAssociations")) |max_associations| {
         _ = try tx.setMaxAutomaticTokenAssociations(@intCast(max_associations));
     }
-    
-    // Set staked account ID if provided
     if (utils.getString(p, "stakedAccountId")) |staked_account_str| {
         const staked_account = try utils.parseAccountId(allocator, staked_account_str);
         _ = try tx.setStakedAccountId(staked_account);
     }
-    
-    // Set staked node ID if provided
     if (utils.getInt(p, "stakedNodeId")) |staked_node| {
         _ = try tx.setStakedNodeId(@intCast(staked_node));
     }
-    
-    // Set decline staking reward if provided
     if (utils.getBool(p, "declineStakingReward")) |decline| {
         _ = try tx.setDeclineStakingReward(decline);
     }
-    
-    // Set account memo if provided
     if (utils.getString(p, "memo")) |memo| {
         _ = try tx.setAccountMemo(memo);
     }
-    
-    // Set auto renew period if provided
     if (utils.getString(p, "autoRenewPeriod")) |period_str| {
         const duration = try utils.parseDuration(period_str);
         _ = try tx.setAutoRenewPeriod(duration);
     }
-    
-    // Set alias if provided
     if (utils.getString(p, "alias")) |alias_str| {
-        // For now, just convert string to bytes
         _ = try tx.setAlias(alias_str);
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     const receipt = try tx_response.getReceipt(c);
-    
-    // Build response
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
-    
     if (receipt.account_id) |account_id| {
         const account_id_str = try std.fmt.allocPrint(allocator, "{}", .{account_id});
         defer allocator.free(account_id_str);
         try response_fields.put("accountId", json.Value{ .string = try allocator.dupe(u8, account_id_str) });
     }
-    
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
-
-// Update account method
 pub fn updateAccount(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Get account ID to update
     const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
     const account_id = try utils.parseAccountId(allocator, account_id_str);
-    
-    // Create transaction
     var tx = hedera.accountUpdateTransaction(allocator);
     defer tx.deinit();
-    
     _ = try tx.setAccountId(account_id);
-    
-    // Set key if provided
     if (utils.getString(p, "key")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setKey(key);
     }
-    
-    // Set expiration time if provided
     if (utils.getString(p, "expirationTime")) |exp_str| {
         const timestamp = try utils.parseTimestamp(exp_str);
         _ = try tx.setExpirationTime(timestamp);
     }
-    
-    // Set receiver signature required if provided
     if (utils.getBool(p, "receiverSignatureRequired")) |required| {
         _ = try tx.setReceiverSignatureRequired(required);
     }
-    
-    // Set max automatic token associations if provided
     if (utils.getInt(p, "maxAutomaticTokenAssociations")) |max_associations| {
         _ = try tx.setMaxAutomaticTokenAssociations(@intCast(max_associations));
     }
-    
-    // Set staked account ID if provided
     if (utils.getString(p, "stakedAccountId")) |staked_account_str| {
         const staked_account = try utils.parseAccountId(allocator, staked_account_str);
         _ = try tx.setStakedAccountId(staked_account);
     }
-    
-    // Set staked node ID if provided
     if (utils.getInt(p, "stakedNodeId")) |staked_node| {
         _ = try tx.setStakedNodeId(@intCast(staked_node));
     }
-    
-    // Set decline staking reward if provided
     if (utils.getBool(p, "declineStakingReward")) |decline| {
         _ = try tx.setDeclineStakingReward(decline);
     }
-    
-    // Set account memo if provided
     if (utils.getString(p, "memo")) |memo| {
         _ = try tx.setAccountMemo(memo);
     }
-    
-    // Set auto renew period if provided
     if (utils.getString(p, "autoRenewPeriod")) |period_str| {
         const duration = try utils.parseDuration(period_str);
         _ = try tx.setAutoRenewPeriod(duration);
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     _ = try tx_response.getReceipt(c);
-    
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-
-// Delete account method
 pub fn deleteAccount(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Get account ID to delete
     const account_id_str = utils.getString(p, "deleteAccountId") orelse return error.MissingAccountId;
     const account_id = try utils.parseAccountId(allocator, account_id_str);
-    
-    // Get transfer account ID
     const transfer_id_str = utils.getString(p, "transferAccountId") orelse return error.MissingTransferAccountId;
     const transfer_id = try utils.parseAccountId(allocator, transfer_id_str);
-    
-    // Create transaction
     var tx = hedera.accountDeleteTransaction(allocator);
     defer tx.deinit();
-    
     _ = try tx.setAccountId(account_id);
     _ = try tx.setTransferAccountId(transfer_id);
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     _ = try tx_response.getReceipt(c);
-    
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-
-// Approve allowance method
 pub fn approveAllowance(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.accountAllowanceApproveTransaction(allocator);
     defer tx.deinit();
-    
-    // Handle HBAR allowances
     if (p.object.get("hbarAllowances")) |allowances| {
         for (allowances.array.items) |allowance| {
             const owner_str = utils.getString(allowance, "owner") orelse continue;
             const spender_str = utils.getString(allowance, "spender") orelse continue;
             const amount_str = utils.getString(allowance, "amount") orelse continue;
-            
             const owner = try utils.parseAccountId(allocator, owner_str);
             const spender = try utils.parseAccountId(allocator, spender_str);
             const amount = try utils.parseHbar(amount_str);
-            
-            try tx.approveHbarAllowance(owner, spender, amount);
+            _ = try tx.approveHbarAllowance(owner, spender, amount);
         }
     }
-    
-    // Handle token allowances
     if (p.object.get("tokenAllowances")) |allowances| {
         for (allowances.array.items) |allowance| {
             const token_str = utils.getString(allowance, "tokenId") orelse continue;
             const owner_str = utils.getString(allowance, "owner") orelse continue;
             const spender_str = utils.getString(allowance, "spender") orelse continue;
             const amount_int = utils.getInt(allowance, "amount") orelse continue;
-            
             const token_id = try utils.parseTokenId(allocator, token_str);
             const owner = try utils.parseAccountId(allocator, owner_str);
             const spender = try utils.parseAccountId(allocator, spender_str);
-            
-            try tx.approveTokenAllowance(token_id, owner, spender, @intCast(amount_int));
+            _ = try tx.approveTokenAllowance(token_id, owner, spender, @intCast(amount_int));
         }
     }
-    
-    // Handle NFT allowances
     if (p.object.get("nftAllowances")) |allowances| {
         for (allowances.array.items) |allowance| {
             const token_str = utils.getString(allowance, "tokenId") orelse continue;
             const owner_str = utils.getString(allowance, "owner") orelse continue;
             const spender_str = utils.getString(allowance, "spender") orelse continue;
-            
             const token_id = try utils.parseTokenId(allocator, token_str);
             const owner = try utils.parseAccountId(allocator, owner_str);
             const spender = try utils.parseAccountId(allocator, spender_str);
-            
             if (allowance.object.get("serialNumbers")) |serial_nums| {
                 for (serial_nums.array.items) |serial| {
                     const nft_id = hedera.NftId.init(token_id, @intCast(serial.integer));
-                    try tx.addNftAllowance(nft_id, owner, spender);
+                    _ = try tx.addNftAllowance(nft_id, owner, spender);
                 }
             } else {
-                try tx.approveNftAllowanceAllSerials(token_id, owner, spender);
+                _ = try tx.approveNftAllowanceAllSerials(token_id, owner, spender);
             }
         }
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     _ = try tx_response.getReceipt(c);
-    
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-
-// Delete allowance method
 pub fn deleteAllowance(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.accountAllowanceDeleteTransaction(allocator);
     defer tx.deinit();
-    
-    // Handle NFT allowance deletions
     if (p.object.get("nftAllowances")) |allowances| {
         for (allowances.array.items) |allowance| {
             const token_str = utils.getString(allowance, "tokenId") orelse continue;
             const owner_str = utils.getString(allowance, "owner") orelse continue;
-            
             const token_id = try utils.parseTokenId(allocator, token_str);
             const owner = try utils.parseAccountId(allocator, owner_str);
-            
             if (allowance.object.get("serialNumbers")) |serial_nums| {
                 for (serial_nums.array.items) |serial| {
                     const nft_id = hedera.NftId.init(token_id, @intCast(serial.integer));
-                    try tx.deleteNftAllowance(nft_id, owner);
+                    _ = try tx.deleteNftAllowance(nft_id, owner);
                 }
             }
         }
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     _ = try tx_response.getReceipt(c);
-    
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-
-// Transfer crypto method
 pub fn transferCrypto(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.transferTransaction(allocator);
     defer tx.deinit();
-    
-    // Handle HBAR transfers
     if (p.object.get("hbarTransfers")) |transfers| {
         for (transfers.array.items) |transfer| {
             const account_str = utils.getString(transfer, "accountId") orelse continue;
             const amount_str = utils.getString(transfer, "amount") orelse continue;
-            
             const account_id = try utils.parseAccountId(allocator, account_str);
             const amount = try utils.parseHbar(amount_str);
-            
-            try tx.addHbarTransfer(account_id, amount);
+            _ = try tx.addHbarTransfer(account_id, amount);
         }
     }
-    
-    // Handle token transfers
     if (p.object.get("tokenTransfers")) |transfers| {
         for (transfers.array.items) |transfer| {
             const token_str = utils.getString(transfer, "tokenId") orelse continue;
             const account_str = utils.getString(transfer, "accountId") orelse continue;
             const amount_int = utils.getInt(transfer, "amount") orelse continue;
-            
             const token_id = try utils.parseTokenId(allocator, token_str);
             const account_id = try utils.parseAccountId(allocator, account_str);
-            
-            try tx.addTokenTransfer(token_id, account_id, amount_int);
+            _ = try tx.addTokenTransfer(token_id, account_id, amount_int);
         }
     }
-    
-    // Handle NFT transfers
     if (p.object.get("nftTransfers")) |transfers| {
         for (transfers.array.items) |transfer| {
             const token_str = utils.getString(transfer, "tokenId") orelse continue;
             const sender_str = utils.getString(transfer, "senderAccountId") orelse continue;
             const receiver_str = utils.getString(transfer, "receiverAccountId") orelse continue;
             const serial_int = utils.getInt(transfer, "serialNumber") orelse continue;
-            
             const token_id = try utils.parseTokenId(allocator, token_str);
             const sender = try utils.parseAccountId(allocator, sender_str);
             const receiver = try utils.parseAccountId(allocator, receiver_str);
-            
             const nft_id = hedera.NftId.init(token_id, @intCast(serial_int));
-            try tx.addNftTransfer(nft_id, sender, receiver);
+            _ = try tx.addNftTransfer(nft_id, sender, receiver);
         }
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     _ = try tx_response.getReceipt(c);
-    
     return try utils.createResponse(allocator, "SUCCESS", null);
 }

--- a/tck/methods/contract_service.zig
+++ b/tck/methods/contract_service.zig
@@ -2,100 +2,71 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.contract_service);
-
 pub fn createContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
-    var tx = hedera.contractCreateTransaction(allocator);
+    var tx = hedera.ContractCreateTransaction.init(allocator);
     defer tx.deinit();
-    
-    // Set bytecode (from file or direct)
     if (utils.getString(p, "bytecodeFileId")) |file_id_str| {
         const file_id = try utils.parseFileId(allocator, file_id_str);
         _ = try tx.setBytecodeFileId(file_id);
     } else if (utils.getString(p, "bytecode")) |bytecode_hex| {
-        // Convert hex string to bytes
         const bytecode_len = bytecode_hex.len / 2;
         const bytecode = try allocator.alloc(u8, bytecode_len);
         defer allocator.free(bytecode);
         _ = try std.fmt.hexToBytes(bytecode, bytecode_hex);
         _ = try tx.setBytecode(bytecode);
     }
-    
-    // Set admin key
     if (utils.getString(p, "adminKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setAdminKey(key);
     }
-    
-    // Set gas
     if (utils.getInt(p, "gas")) |gas| {
         _ = try tx.setGas(@intCast(gas));
     }
-    
-    // Set initial balance
     if (utils.getString(p, "initialBalance")) |balance_str| {
         const hbar = try utils.parseHbar(balance_str);
         _ = try tx.setInitialBalance(hbar);
     }
-    
-    // Set constructor parameters
     if (utils.getString(p, "constructorParameters")) |params_hex| {
-        // Convert hex string to bytes
         const params_len = params_hex.len / 2;
         const params_bytes = try allocator.alloc(u8, params_len);
         defer allocator.free(params_bytes);
         _ = try std.fmt.hexToBytes(params_bytes, params_hex);
         _ = try tx.setConstructorParameters(params_bytes);
     }
-    
-    // Set memo
     if (utils.getString(p, "memo")) |memo| {
-        _ = try tx.setMemo(memo);
+        _ = try tx.setContractMemo(memo);
     }
-    
-    // Set auto renew period
     if (utils.getString(p, "autoRenewPeriod")) |period_str| {
         const duration = try utils.parseDuration(period_str);
         _ = try tx.setAutoRenewPeriod(duration);
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     const receipt = try tx_response.getReceipt(c);
-    
-    // Build response
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
-    
     if (receipt.contract_id) |contract_id| {
         const contract_id_str = try std.fmt.allocPrint(allocator, "{}", .{contract_id});
         try response_fields.put("contractId", json.Value{ .string = try allocator.dupe(u8, contract_id_str) });
         allocator.free(contract_id_str);
     }
-    
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
-
 pub fn updateContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn deleteContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn executeContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;

--- a/tck/methods/file_service.zig
+++ b/tck/methods/file_service.zig
@@ -2,28 +2,19 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.file_service);
-
 pub fn createFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.fileCreateTransaction(allocator);
     defer tx.deinit();
-    
-    // Set keys
     if (utils.getString(p, "keys")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setKeys(key);
     }
-    
-    // Set contents
     if (utils.getString(p, "contents")) |contents_base64| {
-        // Decode base64 contents
         const decoder = std.base64.standard.Decoder;
         const decoded_len = try decoder.calcSizeForSlice(contents_base64);
         const decoded = try allocator.alloc(u8, decoded_len);
@@ -31,48 +22,35 @@ pub fn createFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params:
         _ = try decoder.decode(decoded, contents_base64);
         _ = try tx.setContents(decoded);
     }
-    
-    // Set expiration time
     if (utils.getString(p, "expirationTime")) |exp_str| {
         const timestamp = try utils.parseTimestamp(exp_str);
         _ = try tx.setExpirationTime(timestamp);
     }
-    
-    // Set memo
     if (utils.getString(p, "memo")) |memo| {
         _ = try tx.setMemo(memo);
     }
-    
-    // Execute transaction
-    try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
     const receipt = try tx_response.getReceipt(c);
-    
-    // Build response
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
-    
     if (receipt.file_id) |file_id| {
         const file_id_str = try std.fmt.allocPrint(allocator, "{}", .{file_id});
         try response_fields.put("fileId", json.Value{ .string = try allocator.dupe(u8, file_id_str) });
         allocator.free(file_id_str);
     }
-    
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
-
 pub fn updateFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn deleteFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn appendFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;

--- a/tck/methods/key_service.zig
+++ b/tck/methods/key_service.zig
@@ -2,34 +2,22 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.key_service);
-
-// Generate key method
 pub fn generateKey(allocator: std.mem.Allocator, params: ?json.Value) !json.Value {
-    _ = params; // Key generation doesn't need parameters for now
-    
-    // Generate a new Ed25519 private key
+    _ = params; 
     var private_key = hedera.generatePrivateKey(allocator) catch |err| {
         log.err("Failed to generate private key: {}", .{err});
         return error.KeyGenerationFailed;
     };
     defer private_key.deinit();
-    
     const public_key = private_key.getPublicKey();
-    
-    // Convert keys to strings
     const private_key_str = try private_key.toString(allocator);
     defer allocator.free(private_key_str);
     const public_key_str = try public_key.toString(allocator);
     defer allocator.free(public_key_str);
-    
-    // Build response
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
-    
     try response_fields.put("privateKey", json.Value{ .string = try allocator.dupe(u8, private_key_str) });
     try response_fields.put("publicKey", json.Value{ .string = try allocator.dupe(u8, public_key_str) });
-    
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }

--- a/tck/methods/node_service.zig
+++ b/tck/methods/node_service.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+const hedera = @import("hedera");
+const json = std.json;
+const utils = @import("../utils/utils.zig");
+pub fn createNode(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const account_id = try utils.getStringParam(p, "accountId");
+    const description = try utils.getOptionalStringParam(p, "description");
+    const gossip_endpoint = try utils.getOptionalStringParam(p, "gossipEndpoint");
+    const service_endpoint = try utils.getOptionalStringParam(p, "serviceEndpoint");
+    const admin_key = try utils.getOptionalStringParam(p, "adminKey");
+    const gossip_ca_certificate = try utils.getOptionalStringParam(p, "gossipCaCertificate");
+    const grpc_certificate_hash = try utils.getOptionalStringParam(p, "grpcCertificateHash");
+    var tx = hedera.NodeCreateTransaction.init(allocator);
+    defer tx.deinit();
+    const acc_id = try hedera.AccountId.fromString(allocator, account_id);
+    _ = try tx.setAccountId(acc_id);
+    if (description) |desc| {
+        _ = try tx.setDescription(desc);
+    }
+    if (gossip_endpoint) |endpoint| {
+        var parts = std.mem.splitScalar(u8, endpoint, ':');
+        var ip_str: []const u8 = "";
+        var port_str: []const u8 = "50211";
+        if (parts.next()) |ip| {
+            ip_str = ip;
+        }
+        if (parts.next()) |port| {
+            port_str = port;
+        }
+        const port = try std.fmt.parseInt(u16, port_str, 10);
+        const endpoint_obj = hedera.NodeServiceEndpoint{
+            .ip_address = ip_str,
+            .port = @as(u32, @intCast(port)),
+            .domain_name = "",
+        };
+        try tx.addGossipEndpoint(endpoint_obj);
+    }
+    if (service_endpoint) |endpoint| {
+        var parts = std.mem.splitScalar(u8, endpoint, ':');
+        var ip_str: []const u8 = "";
+        var port_str: []const u8 = "50211";
+        if (parts.next()) |ip| {
+            ip_str = ip;
+        }
+        if (parts.next()) |port| {
+            port_str = port;
+        }
+        const port = try std.fmt.parseInt(u16, port_str, 10);
+        const endpoint_obj = hedera.NodeServiceEndpoint{
+            .ip_address = ip_str,
+            .port = @as(u32, @intCast(port)),
+            .domain_name = "",
+        };
+        try tx.addServiceEndpoint(endpoint_obj);
+    }
+    if (admin_key) |key_str| {
+        const key = try utils.parseKey(allocator, key_str);
+        _ = try tx.setAdminKey(key);
+    }
+    if (gossip_ca_certificate) |cert| {
+        _ = try tx.setGossipCaCertificate(cert);
+    }
+    if (grpc_certificate_hash) |hash| {
+        const decoded_size = std.base64.standard.Decoder.calcSizeForSlice(hash) catch return error.InvalidBase64;
+        const decoded = try allocator.alloc(u8, decoded_size);
+        defer allocator.free(decoded);
+        _ = try std.base64.standard.Decoder.decode(decoded, hash);
+        _ = try tx.setGrpcCertificateHash(decoded);
+    }
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("nodeId", json.Value{ .integer = @intCast(receipt.node_id) });
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    return json.Value{ .object = result };
+}
+pub fn updateNode(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const node_id = try utils.getNumberParam(p, "nodeId");
+    const account_id = try utils.getOptionalStringParam(p, "accountId");
+    const description = try utils.getOptionalStringParam(p, "description");
+    const gossip_endpoint = try utils.getOptionalStringParam(p, "gossipEndpoint");
+    const service_endpoint = try utils.getOptionalStringParam(p, "serviceEndpoint");
+    const admin_key = try utils.getOptionalStringParam(p, "adminKey");
+    const gossip_ca_certificate = try utils.getOptionalStringParam(p, "gossipCaCertificate");
+    const grpc_certificate_hash = try utils.getOptionalStringParam(p, "grpcCertificateHash");
+    var tx = hedera.NodeUpdateTransaction.init(allocator);
+    defer tx.deinit();
+    _ = try tx.setNodeId(@intCast(node_id));
+    if (account_id) |acc_str| {
+        const acc_id = try hedera.AccountId.fromString(allocator, acc_str);
+        _ = try tx.setAccountId(acc_id);
+    }
+    if (description) |desc| {
+        _ = try tx.setDescription(desc);
+    }
+    _ = gossip_endpoint;
+    _ = service_endpoint;
+    if (admin_key) |key_str| {
+        const key = try utils.parseKey(allocator, key_str);
+        _ = try tx.setAdminKey(key);
+    }
+    if (gossip_ca_certificate) |cert| {
+        _ = try tx.setGossipCaCertificate(cert);
+    }
+    if (grpc_certificate_hash) |hash| {
+        const decoded_size = std.base64.standard.Decoder.calcSizeForSlice(hash) catch return error.InvalidBase64;
+        const decoded = try allocator.alloc(u8, decoded_size);
+        defer allocator.free(decoded);
+        _ = try std.base64.standard.Decoder.decode(decoded, hash);
+        _ = try tx.setGrpcCertificateHash(decoded);
+    }
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    return json.Value{ .object = result };
+}
+pub fn deleteNode(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const node_id = try utils.getNumberParam(p, "nodeId");
+    var tx = hedera.NodeDeleteTransaction.init(allocator);
+    defer tx.deinit();
+    _ = try tx.setNodeId(@intCast(node_id));
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    return json.Value{ .object = result };
+}

--- a/tck/methods/query_service.zig
+++ b/tck/methods/query_service.zig
@@ -1,0 +1,368 @@
+const std = @import("std");
+const hedera = @import("hedera");
+const json = std.json;
+const utils = @import("../utils/utils.zig");
+pub fn getAccountInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const account_id = try utils.getStringParam(p, "accountId");
+    var query = hedera.AccountInfoQuery.init(allocator);
+    defer query.deinit();
+    const acc_id = try hedera.AccountId.fromString(allocator, account_id);
+    _ = try query.setAccountId(acc_id);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("accountId", json.Value{ .string = try info.account_id.toString(allocator) });
+    try result.put("balance", json.Value{ .integer = @intCast(info.balance.tinybars) });
+    try result.put("ethereumNonce", json.Value{ .integer = @intCast(info.ethereum_nonce) });
+    try result.put("maxAutoTokenAssociations", json.Value{ .integer = @intCast(info.max_automatic_token_associations) });
+    try result.put("key", json.Value{ .string = try info.key.toString(allocator) });
+    if (info.alias.len > 0) {
+        const encoded = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(info.alias.len));
+        _ = std.base64.standard.Encoder.encode(encoded, info.alias);
+        try result.put("alias", json.Value{ .string = encoded });
+    }
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    try result.put("receiverSignatureRequired", json.Value{ .bool = info.receiver_signature_required });
+    try result.put("deleted", json.Value{ .bool = info.deleted });
+    try result.put("expirationTime", json.Value{ .integer = @intCast(info.expiration_time.seconds) });
+    if (info.staking_info) |staking| {
+        var staking_map = std.json.ObjectMap.init(allocator);
+        try staking_map.put("declineReward", json.Value{ .bool = staking.decline_reward });
+        try staking_map.put("stakedToMe", json.Value{ .integer = @intCast(staking.staked_to_me) });
+        if (staking.staked_node_id) |node_id| {
+            try staking_map.put("stakedNodeId", json.Value{ .integer = @intCast(node_id) });
+        }
+        if (staking.staked_account_id) |acc_id_staked| {
+            try staking_map.put("stakedAccountId", json.Value{ .string = try acc_id_staked.toString(allocator) });
+        }
+        try result.put("stakingInfo", json.Value{ .object = staking_map });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getAccountBalance(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const account_id = try utils.getStringParam(p, "accountId");
+    var query = hedera.AccountBalanceQuery.init(allocator);
+    defer query.deinit();
+    const acc_id = try hedera.AccountId.fromString(allocator, account_id);
+    _ = try query.setAccountId(acc_id);
+    var balance = try query.execute(client.?);
+    defer balance.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("balance", json.Value{ .integer = @intCast(balance.hbars.tinybars) });
+    if (balance.tokens.count() > 0) {
+        var tokens_array = std.json.Array.init(allocator);
+        var token_iter = balance.tokens.iterator();
+        while (token_iter.next()) |entry| {
+            var token_map = std.json.ObjectMap.init(allocator);
+            try token_map.put("tokenId", json.Value{ .string = try entry.key_ptr.*.toString(allocator) });
+            try token_map.put("balance", json.Value{ .integer = @intCast(entry.value_ptr.*) });
+            try tokens_array.append(json.Value{ .object = token_map });
+        }
+        try result.put("tokens", json.Value{ .array = tokens_array });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getTokenInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const token_id = try utils.getStringParam(p, "tokenId");
+    var query = hedera.TokenInfoQuery.init(allocator);
+    defer query.deinit();
+    const tid = try hedera.TokenId.fromString(allocator, token_id);
+    _ = try query.setTokenId(tid);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("tokenId", json.Value{ .string = try info.token_id.toString(allocator) });
+    try result.put("name", json.Value{ .string = info.name });
+    try result.put("symbol", json.Value{ .string = info.symbol });
+    try result.put("decimals", json.Value{ .integer = @intCast(info.decimals) });
+    try result.put("totalSupply", json.Value{ .integer = @intCast(info.total_supply) });
+    if (info.treasury_account_id) |treasury| {
+        try result.put("treasuryAccountId", json.Value{ .string = try treasury.toString(allocator) });
+    }
+    if (info.admin_key) |key| {
+        try result.put("adminKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.supply_key) |key| {
+        try result.put("supplyKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.freeze_key) |key| {
+        try result.put("freezeKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.wipe_key) |key| {
+        try result.put("wipeKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.kyc_key) |key| {
+        try result.put("kycKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.pause_key) |key| {
+        try result.put("pauseKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.metadata_key) |key| {
+        try result.put("metadataKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.fee_schedule_key) |key| {
+        try result.put("feeScheduleKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    try result.put("tokenType", json.Value{ .string = @tagName(info.token_type) });
+    try result.put("supplyType", json.Value{ .string = @tagName(info.supply_type) });
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    try result.put("deleted", json.Value{ .bool = info.deleted });
+    try result.put("paused", json.Value{ .bool = info.pause_status });
+    if (info.auto_renew_account) |renew_acc| {
+        try result.put("autoRenewAccount", json.Value{ .string = try renew_acc.toString(allocator) });
+    }
+    try result.put("autoRenewPeriod", json.Value{ .integer = @intCast(info.auto_renew_period.seconds) });
+    if (info.expiry) |expiry| {
+        try result.put("expirationTime", json.Value{ .integer = @intCast(expiry.seconds) });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getTokenBalance(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const token_id = try utils.getStringParam(p, "tokenId");
+    const account_id = try utils.getStringParam(p, "accountId");
+    var query = hedera.AccountBalanceQuery.init(allocator);
+    defer query.deinit();
+    const acc_id = try hedera.AccountId.fromString(allocator, account_id);
+    _ = try query.setAccountId(acc_id);
+    var balance = try query.execute(client.?);
+    defer balance.deinit();
+    const tid = try hedera.TokenId.fromString(allocator, token_id);
+    var result = std.json.ObjectMap.init(allocator);
+    if (balance.tokens.get(tid)) |token_balance| {
+        try result.put("balance", json.Value{ .integer = @intCast(token_balance) });
+    } else {
+        try result.put("balance", json.Value{ .integer = 0 });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getFileInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const file_id = try utils.getStringParam(p, "fileId");
+    var query = hedera.FileInfoQuery.init(allocator);
+    defer query.deinit();
+    const fid = try hedera.FileId.fromString(allocator, file_id);
+    _ = try query.setFileId(fid);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("fileId", json.Value{ .string = try info.file_id.toString(allocator) });
+    try result.put("size", json.Value{ .integer = @intCast(info.size) });
+    try result.put("expirationTime", json.Value{ .integer = @intCast(info.expiration_time.seconds) });
+    try result.put("deleted", json.Value{ .bool = info.deleted });
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    if (info.keys.items.len > 0) {
+        try result.put("adminKey", json.Value{ .string = try info.keys.items[0].toString(allocator) });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getFileContents(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const file_id = try utils.getStringParam(p, "fileId");
+    var query = hedera.FileContentsQuery.init(allocator);
+    defer query.deinit();
+    const fid = try hedera.FileId.fromString(allocator, file_id);
+    _ = try query.setFileId(fid);
+    var file_contents = try query.execute(client.?);
+    defer file_contents.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    const encoded = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(file_contents.contents.len));
+    _ = std.base64.standard.Encoder.encode(encoded, file_contents.contents);
+    try result.put("contents", json.Value{ .string = encoded });
+    return json.Value{ .object = result };
+}
+pub fn getTopicInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const topic_id = try utils.getStringParam(p, "topicId");
+    var query = hedera.TopicInfoQuery.init(allocator);
+    defer query.deinit();
+    const tid = try hedera.TopicId.fromString(allocator, topic_id);
+    _ = try query.setTopicId(tid);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("topicId", json.Value{ .string = try info.topic_id.toString(allocator) });
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    if (info.admin_key) |key| {
+        try result.put("adminKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.submit_key) |key| {
+        try result.put("submitKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.auto_renew_account) |acc| {
+        try result.put("autoRenewAccount", json.Value{ .string = try acc.toString(allocator) });
+    }
+    try result.put("autoRenewPeriod", json.Value{ .integer = @intCast(info.auto_renew_period.seconds) });
+    try result.put("expirationTime", json.Value{ .integer = @intCast(info.expiration_time.seconds) });
+    try result.put("sequenceNumber", json.Value{ .integer = @intCast(info.sequence_number) });
+    return json.Value{ .object = result };
+}
+pub fn getContractInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const contract_id = try utils.getStringParam(p, "contractId");
+    var query = hedera.ContractInfoQuery.init(allocator);
+    defer query.deinit();
+    const cid = try hedera.ContractId.fromString(allocator, contract_id);
+    _ = try query.setContractId(cid);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("contractId", json.Value{ .string = try info.contract_id.toString(allocator) });
+    try result.put("accountId", json.Value{ .string = try info.account_id.toString(allocator) });
+    if (info.contract_account_id.len > 0) {
+        try result.put("contractAccountId", json.Value{ .string = info.contract_account_id });
+    }
+    if (info.admin_key) |key| {
+        try result.put("adminKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    try result.put("storage", json.Value{ .integer = @intCast(info.storage) });
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    try result.put("balance", json.Value{ .integer = @intCast(info.balance) });
+    try result.put("deleted", json.Value{ .bool = info.deleted });
+    try result.put("autoRenewPeriod", json.Value{ .integer = @intCast(info.auto_renew_period.seconds) });
+    if (info.auto_renew_account_id) |acc| {
+        try result.put("autoRenewAccountId", json.Value{ .string = try acc.toString(allocator) });
+    }
+    try result.put("maxAutoTokenAssociations", json.Value{ .integer = @intCast(info.max_automatic_token_associations) });
+    return json.Value{ .object = result };
+}
+pub fn getTransactionRecord(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const transaction_id = try utils.getStringParam(p, "transactionId");
+    var query = hedera.TransactionRecordQuery.init(allocator);
+    defer query.deinit();
+    const tx_id = try hedera.TransactionId.fromString(allocator, transaction_id);
+    _ = try query.setTransactionId(tx_id);
+    var record = try query.execute(client.?);
+    defer record.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    if (record.transaction_id) |tid| {
+        try result.put("transactionId", json.Value{ .string = try tid.toString(allocator) });
+    }
+    if (record.receipt) |receipt| {
+        try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    }
+    if (record.transaction_hash) |hash| {
+        const encoded = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(hash.len));
+        _ = std.base64.standard.Encoder.encode(encoded, hash);
+        try result.put("transactionHash", json.Value{ .string = encoded });
+    }
+    if (record.transaction_fee) |fee| {
+        try result.put("transactionFee", json.Value{ .integer = @intCast(fee) });
+    }
+    if (record.consensus_timestamp) |timestamp| {
+        try result.put("consensusTimestamp", json.Value{ .integer = @intCast(timestamp.seconds) });
+    }
+    if (record.memo) |memo| {
+        try result.put("memo", json.Value{ .string = memo });
+    }
+    if (record.transfers) |transfers| {
+        var transfers_array = std.json.Array.init(allocator);
+        for (transfers) |transfer| {
+            var transfer_map = std.json.ObjectMap.init(allocator);
+            try transfer_map.put("accountId", json.Value{ .string = try transfer.account_id.toString(allocator) });
+            try transfer_map.put("amount", json.Value{ .integer = @intCast(transfer.amount) });
+            try transfers_array.append(json.Value{ .object = transfer_map });
+        }
+        try result.put("transfers", json.Value{ .array = transfers_array });
+    }
+    return json.Value{ .object = result };
+}
+pub fn getTransactionReceipt(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = (try utils.createErrorMap(allocator, "Client not configured")) };
+    }
+    const p = params orelse return json.Value{ .object = (try utils.createErrorMap(allocator, "Invalid parameters")) };
+    const transaction_id = try utils.getStringParam(p, "transactionId");
+    var query = hedera.TransactionReceiptQuery.init(allocator);
+    defer query.deinit();
+    const tx_id = try hedera.TransactionId.fromString(allocator, transaction_id);
+    _ = try query.setTransactionId(tx_id);
+    var receipt = try query.execute(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    if (receipt.account_id) |acc_id| {
+        try result.put("accountId", json.Value{ .string = try acc_id.toString(allocator) });
+    }
+    if (receipt.token_id) |tid| {
+        try result.put("tokenId", json.Value{ .string = try tid.toString(allocator) });
+    }
+    if (receipt.file_id) |fid| {
+        try result.put("fileId", json.Value{ .string = try fid.toString(allocator) });
+    }
+    if (receipt.contract_id) |cid| {
+        try result.put("contractId", json.Value{ .string = try cid.toString(allocator) });
+    }
+    if (receipt.topic_id) |tid| {
+        try result.put("topicId", json.Value{ .string = try tid.toString(allocator) });
+    }
+    if (receipt.schedule_id) |sid| {
+        try result.put("scheduleId", json.Value{ .string = try sid.toString(allocator) });
+    }
+    if (receipt.topic_sequence_number) |seq| {
+        try result.put("topicSequenceNumber", json.Value{ .integer = @intCast(seq) });
+    }
+    if (receipt.topic_running_hash) |hash| {
+        const encoded = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(hash.len));
+        _ = std.base64.standard.Encoder.encode(encoded, hash);
+        try result.put("topicRunningHash", json.Value{ .string = encoded });
+    }
+    if (receipt.serials) |serials| {
+        var serials_array = std.json.Array.init(allocator);
+        for (serials) |serial| {
+            try serials_array.append(json.Value{ .integer = @intCast(serial) });
+        }
+        try result.put("serials", json.Value{ .array = serials_array });
+    }
+    if (receipt.total_supply) |supply| {
+        try result.put("totalSupply", json.Value{ .integer = @intCast(supply) });
+    }
+    if (receipt.exchange_rate) |rate| {
+        var rate_map = std.json.ObjectMap.init(allocator);
+        try rate_map.put("hbars", json.Value{ .integer = @intCast(rate.hbars) });
+        try rate_map.put("cents", json.Value{ .integer = @intCast(rate.cents) });
+        try result.put("exchangeRate", json.Value{ .object = rate_map });
+    }
+    return json.Value{ .object = result };
+}

--- a/tck/methods/schedule_service.zig
+++ b/tck/methods/schedule_service.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const hedera = @import("hedera");
+const json = std.json;
+const utils = @import("../utils/utils.zig");
+pub fn createSchedule(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = try utils.createErrorMap(allocator, "Client not configured") };
+    }
+    const p = params orelse return json.Value{ .object = try utils.createErrorMap(allocator, "Invalid parameters") };
+    const transaction_bytes = try utils.getStringParam(p, "transactionBytes");
+    const memo = try utils.getOptionalStringParam(p, "memo");
+    const admin_key = try utils.getOptionalStringParam(p, "adminKey");
+    const payer_account_id = try utils.getOptionalStringParam(p, "payerAccountId");
+    const expiration_time = try utils.getOptionalNumberParam(p, "expirationTime");
+    const wait_for_expiry = try utils.getOptionalBoolParam(p, "waitForExpiry");
+    var tx = hedera.ScheduleCreateTransaction.init(allocator);
+    defer tx.deinit();
+    const decoded_size = std.base64.standard.Decoder.calcSizeForSlice(transaction_bytes) catch return error.InvalidBase64;
+    const decoded = try allocator.alloc(u8, decoded_size);
+    defer allocator.free(decoded);
+    _ = try std.base64.standard.Decoder.decode(decoded, transaction_bytes);
+    if (memo) |m| {
+        _ = try tx.setScheduleMemo(m);
+    }
+    if (admin_key) |key_str| {
+        const key = try utils.parseKey(allocator, key_str);
+        _ = try tx.setAdminKey(key);
+    }
+    if (payer_account_id) |payer_str| {
+        const payer = try hedera.AccountId.fromString(allocator, payer_str);
+        _ = try tx.setPayerAccountId(payer);
+    }
+    if (expiration_time) |exp_time| {
+        const timestamp = hedera.Timestamp{ .seconds = @intCast(exp_time), .nanos = 0 };
+        _ = try tx.setExpirationTime(timestamp);
+    }
+    if (wait_for_expiry) |wait| {
+        _ = try tx.setWaitForExpiry(wait);
+    }
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    if (receipt.schedule_id) |schedule_id| {
+        var result = std.json.ObjectMap.init(allocator);
+        try result.put("scheduleId", json.Value{ .string = try schedule_id.toString(allocator) });
+        try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+        return json.Value{ .object = result };
+    }
+    return json.Value{ .object = try utils.createErrorMap(allocator, "Failed to create schedule") };
+}
+pub fn signSchedule(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = try utils.createErrorMap(allocator, "Client not configured") };
+    }
+    const p = params orelse return json.Value{ .object = try utils.createErrorMap(allocator, "Invalid parameters") };
+    const schedule_id = try utils.getStringParam(p, "scheduleId");
+    var tx = hedera.ScheduleSignTransaction.init(allocator);
+    defer tx.deinit();
+    const sid = try hedera.ScheduleId.fromString(allocator, schedule_id);
+    _ = try tx.setScheduleId(sid);
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    return json.Value{ .object = result };
+}
+pub fn deleteSchedule(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = try utils.createErrorMap(allocator, "Client not configured") };
+    }
+    const p = params orelse return json.Value{ .object = try utils.createErrorMap(allocator, "Invalid parameters") };
+    const schedule_id = try utils.getStringParam(p, "scheduleId");
+    var tx = hedera.ScheduleDeleteTransaction.init(allocator);
+    defer tx.deinit();
+    const sid = try hedera.ScheduleId.fromString(allocator, schedule_id);
+    _ = try tx.setScheduleId(sid);
+    var response = try tx.execute(client.?);
+    defer response.deinit();
+    var receipt = try response.getReceipt(client.?);
+    defer receipt.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("status", json.Value{ .string = @tagName(receipt.status) });
+    return json.Value{ .object = result };
+}
+pub fn getScheduleInfo(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
+    if (client == null) {
+        return json.Value{ .object = try utils.createErrorMap(allocator, "Client not configured") };
+    }
+    const p = params orelse return json.Value{ .object = try utils.createErrorMap(allocator, "Invalid parameters") };
+    const schedule_id = try utils.getStringParam(p, "scheduleId");
+    var query = hedera.ScheduleInfoQuery.init(allocator);
+    defer query.deinit();
+    const sid = try hedera.ScheduleId.fromString(allocator, schedule_id);
+    _ = try query.setScheduleId(sid);
+    var info = try query.execute(client.?);
+    defer info.deinit();
+    var result = std.json.ObjectMap.init(allocator);
+    try result.put("scheduleId", json.Value{ .string = try info.schedule_id.toString(allocator) });
+    if (info.memo.len > 0) {
+        try result.put("memo", json.Value{ .string = info.memo });
+    }
+    try result.put("creatorAccountId", json.Value{ .string = try info.creator_account_id.toString(allocator) });
+    try result.put("payerAccountId", json.Value{ .string = try info.payer_account_id.toString(allocator) });
+    if (info.admin_key) |key| {
+        try result.put("adminKey", json.Value{ .string = try key.toString(allocator) });
+    }
+    if (info.executed_at) |exec_time| {
+        try result.put("executedAt", json.Value{ .integer = @intCast(exec_time.seconds) });
+    }
+    if (info.deleted_at) |del_time| {
+        try result.put("deletedAt", json.Value{ .integer = @intCast(del_time.seconds) });
+    }
+    try result.put("expirationTime", json.Value{ .integer = @intCast(info.expiration_time.seconds) });
+    return json.Value{ .object = result };
+}

--- a/tck/methods/sdk_service.zig
+++ b/tck/methods/sdk_service.zig
@@ -2,28 +2,20 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.sdk_service);
-
-// Setup parameters
 pub const SetupParams = struct {
     operatorAccountId: ?[]const u8 = null,
     operatorPrivateKey: ?[]const u8 = null,
     nodeIp: ?[]const u8 = null,
     nodeAccountId: ?[]const u8 = null,
     mirrorNetworkIp: ?[]const u8 = null,
-    network: ?[]const u8 = null, // "testnet", "mainnet", "previewnet", or custom
+    network: ?[]const u8 = null, 
 };
-
-// Setup the SDK client
 pub fn setup(allocator: std.mem.Allocator, client_ptr: *?*hedera.Client, params: ?json.Value) !json.Value {
-    // Clean up existing client if any
     if (client_ptr.*) |client| {
         client.deinit();
         client_ptr.* = null;
     }
-    
-    // Parse parameters
     var setup_params = SetupParams{};
     if (params) |p| {
         if (utils.getString(p, "operatorAccountId")) |op_id| setup_params.operatorAccountId = op_id;
@@ -33,10 +25,7 @@ pub fn setup(allocator: std.mem.Allocator, client_ptr: *?*hedera.Client, params:
         if (utils.getString(p, "mirrorNetworkIp")) |mirror_ip| setup_params.mirrorNetworkIp = mirror_ip;
         if (utils.getString(p, "network")) |network| setup_params.network = network;
     }
-    
-    // Create client based on network parameter
     var client: *hedera.Client = undefined;
-    
     if (setup_params.network) |network| {
         if (std.mem.eql(u8, network, "testnet")) {
             client = try allocator.create(hedera.Client);
@@ -51,65 +40,43 @@ pub fn setup(allocator: std.mem.Allocator, client_ptr: *?*hedera.Client, params:
             client.* = try hedera.Client.forPreviewnet();
             log.info("Client configured for Previewnet", .{});
         } else if (std.mem.eql(u8, network, "local-node")) {
-            // For local node, just use testnet for now and modify later
             client = try allocator.create(hedera.Client);
             client.* = try hedera.Client.forTestnet();
             log.info("Client configured for Local Node (using testnet base)", .{});
-            
-            // Local node network setup would go here
             _ = setup_params.nodeIp;
             _ = setup_params.nodeAccountId;
         } else {
             return error.InvalidNetwork;
         }
     } else {
-        // Default to testnet
         client = try allocator.create(hedera.Client);
         client.* = try hedera.Client.forTestnet();
         log.info("Client configured for Testnet (default)", .{});
     }
-    
-    // Set operator if provided
     if (setup_params.operatorAccountId) |account_id_str| {
         if (setup_params.operatorPrivateKey) |private_key_str| {
             const account_id = try utils.parseAccountId(allocator, account_id_str);
             var private_key = try utils.parsePrivateKey(allocator, private_key_str);
             defer private_key.deinit();
-            
             const operator_key = try private_key.toOperatorKey();
             _ = try client.setOperator(account_id, operator_key);
-            
             log.info("Operator set: {s}", .{account_id_str});
         }
     }
-    
-    // Set mirror network if provided
     if (setup_params.mirrorNetworkIp) |mirror_ip| {
-        // Mirror network setup would go here
         _ = mirror_ip;
         log.info("Mirror network configuration skipped for now", .{});
     }
-    
-    // Store client
     client_ptr.* = client;
-    
-    // Return success status
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-
-// Reset the SDK client
 pub fn reset(allocator: std.mem.Allocator, client_ptr: *?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = params; // Unused
-    
-    // Clean up existing client
+    _ = params; 
     if (client_ptr.*) |client| {
         client.deinit();
         allocator.destroy(client);
         client_ptr.* = null;
         log.info("Client reset successfully", .{});
     }
-    
-    // Return success status
     return try utils.createResponse(allocator, "SUCCESS", null);
 }
-

--- a/tck/methods/token_service.zig
+++ b/tck/methods/token_service.zig
@@ -2,100 +2,68 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.token_service);
-
 pub fn createToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = hedera.tokenCreateTransaction(allocator);
     defer tx.deinit();
-    
-    // Set name
     if (utils.getString(p, "name")) |name| {
         _ = try tx.setTokenName(name);
     }
-    
-    // Set symbol
     if (utils.getString(p, "symbol")) |symbol| {
         _ = try tx.setTokenSymbol(symbol);
     }
-    
-    // Set decimals
     if (utils.getInt(p, "decimals")) |decimals| {
         _ = try tx.setDecimals(@intCast(decimals));
     }
-    
-    // Set initial supply
     if (utils.getInt(p, "initialSupply")) |supply| {
         _ = try tx.setInitialSupply(@intCast(supply));
     }
-    
-    // Set treasury account
     if (utils.getString(p, "treasuryAccountId")) |treasury_str| {
         const treasury = try utils.parseAccountId(allocator, treasury_str);
         _ = try tx.setTreasuryAccountId(treasury);
     }
-    
-    // Set admin key
     if (utils.getString(p, "adminKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setAdminKey(key);
     }
-    
-    // Set KYC key
     if (utils.getString(p, "kycKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setKycKey(key);
     }
-    
-    // Set freeze key
     if (utils.getString(p, "freezeKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setFreezeKey(key);
     }
-    
-    // Set wipe key
     if (utils.getString(p, "wipeKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setWipeKey(key);
     }
-    
-    // Set supply key
     if (utils.getString(p, "supplyKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setSupplyKey(key);
     }
-    
-    // Set freeze default
     if (utils.getBool(p, "freezeDefault")) |freeze_default| {
         _ = try tx.setFreezeDefault(freeze_default);
     }
-    
-    // Set auto renew period
     if (utils.getString(p, "autoRenewPeriod")) |period_str| {
         const duration = try utils.parseDuration(period_str);
         _ = try tx.setAutoRenewPeriod(duration);
     }
-    
-    // Set memo
     if (utils.getString(p, "memo")) |memo| {
         _ = try tx.setTokenMemo(memo);
     }
-    
-    // Set token type
     if (utils.getString(p, "tokenType")) |type_str| {
         const token_type = if (std.mem.eql(u8, type_str, "nft")) 
             hedera.TokenType.non_fungible_unique 
@@ -103,8 +71,6 @@ pub fn createToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params
             hedera.TokenType.fungible_common;
         _ = try tx.setTokenType(token_type);
     }
-    
-    // Set supply type
     if (utils.getString(p, "supplyType")) |type_str| {
         const supply_type = if (std.mem.eql(u8, type_str, "finite"))
             hedera.TokenSupplyType.finite
@@ -112,147 +78,111 @@ pub fn createToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params
             hedera.TokenSupplyType.infinite;
         _ = try tx.setSupplyType(supply_type);
     }
-    
-    // Set max supply
     if (utils.getInt(p, "maxSupply")) |max_supply| {
         _ = try tx.setMaxSupply(max_supply);
     }
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    const receipt = try tx_response.getReceipt(c);
     
-    // For TCK, we just freeze and serialize the transaction, not execute it
-    // TCK is for testing SDK functionality, not executing against real network
-    try tx.freezeWith(c);
-    
-    // Get the transaction bytes (this would be sent to Hedera in production)
-    const tx_bytes = try tx.base.buildTransactionBody();
-    defer allocator.free(tx_bytes);
-    
-    // Build response with transaction info
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
     
-    // Include transaction ID for reference
-    if (tx.base.transaction_id) |tx_id| {
-        const tx_id_str = try std.fmt.allocPrint(allocator, "{}.{}.{}-{}.{}", .{
-            tx_id.account_id.shard,
-            tx_id.account_id.realm,
-            tx_id.account_id.account,
-            tx_id.valid_start.seconds,
-            tx_id.valid_start.nanos,
-        });
-        try response_fields.put("transactionId", json.Value{ .string = try allocator.dupe(u8, tx_id_str) });
-        allocator.free(tx_id_str);
+    if (receipt.token_id) |token_id| {
+        const token_id_str = try std.fmt.allocPrint(allocator, "{}", .{token_id});
+        defer allocator.free(token_id_str);
+        try response_fields.put("tokenId", json.Value{ .string = try allocator.dupe(u8, token_id_str) });
     }
     
-    // Include serialized transaction size
-    const size_str = try std.fmt.allocPrint(allocator, "{}", .{tx_bytes.len});
-    try response_fields.put("transactionSize", json.Value{ .string = try allocator.dupe(u8, size_str) });
-    allocator.free(size_str);
+    try response_fields.put("status", json.Value{ .string = @tagName(receipt.status) });
     
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
-
 pub fn updateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn deleteToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn updateTokenFeeSchedule(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn associateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn dissociateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn pauseToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn unpauseToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn freezeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn unfreezeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn grantTokenKyc(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn revokeTokenKyc(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn mintToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn burnToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn wipeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn claimToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn airdropToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn cancelAirdrop(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn rejectToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;

--- a/tck/methods/topic_service.zig
+++ b/tck/methods/topic_service.zig
@@ -2,80 +2,57 @@ const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
 const utils = @import("../utils/utils.zig");
-
 const log = std.log.scoped(.topic_service);
-
 pub fn createTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     const c = client orelse return error.ClientNotConfigured;
     const p = params orelse return error.MissingParams;
-    
-    // Create transaction
     var tx = try hedera.topicCreateTransaction(allocator);
     defer tx.deinit();
-    
-    // Set admin key
     if (utils.getString(p, "adminKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setAdminKey(key);
     }
-    
-    // Set submit key
     if (utils.getString(p, "submitKey")) |key_str| {
         var private_key = try utils.parsePrivateKey(allocator, key_str);
         defer private_key.deinit();
         const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
         _ = try tx.setSubmitKey(key);
     }
-    
-    // Set memo
     if (utils.getString(p, "memo")) |memo| {
         _ = try tx.setTopicMemo(memo);
     }
-    
-    // Set auto renew period
     if (utils.getString(p, "autoRenewPeriod")) |period_str| {
         const duration = try utils.parseDuration(period_str);
         _ = try tx.setAutoRenewPeriod(duration);
     }
-    
-    // Set auto renew account
     if (utils.getString(p, "autoRenewAccount")) |account_str| {
         const account = try utils.parseAccountId(allocator, account_str);
         _ = try tx.setAutoRenewAccountId(account);
     }
-    
-    // Execute transaction
     _ = try tx.freezeWith(c);
-    const tx_response = try tx.execute(c);
+    var tx_response = try tx.execute(c);
     const receipt = try tx_response.getReceipt(c);
-    
-    // Build response
     var response_fields = json.ObjectMap.init(allocator);
     defer response_fields.deinit();
-    
     if (receipt.topic_id) |topic_id| {
         const topic_id_str = try std.fmt.allocPrint(allocator, "{}", .{topic_id});
         try response_fields.put("topicId", json.Value{ .string = try allocator.dupe(u8, topic_id_str) });
         allocator.free(topic_id_str);
     }
-    
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
-
 pub fn updateTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn deleteTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
     return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
 }
-
 pub fn submitTopicMessage(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;

--- a/tck/server.zig
+++ b/tck/server.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const hedera = @import("hedera");
 const json_rpc = @import("json_rpc.zig");
+const utils = @import("utils/utils.zig");
 const sdk_service = @import("methods/sdk_service.zig");
 const account_service = @import("methods/account_service.zig");
 const token_service = @import("methods/token_service.zig");
@@ -8,14 +9,14 @@ const file_service = @import("methods/file_service.zig");
 const topic_service = @import("methods/topic_service.zig");
 const contract_service = @import("methods/contract_service.zig");
 const key_service = @import("methods/key_service.zig");
-
+const schedule_service = @import("methods/schedule_service.zig");
+const node_service = @import("methods/node_service.zig");
+const query_service = @import("methods/query_service.zig");
 const log = std.log.scoped(.tck_server);
-
 pub const TCKServer = struct {
     allocator: std.mem.Allocator,
     client: ?*hedera.Client,
     port: u16,
-    
     pub fn init(allocator: std.mem.Allocator, port: u16) TCKServer {
         return .{
             .allocator = allocator,
@@ -23,16 +24,13 @@ pub const TCKServer = struct {
             .port = port,
         };
     }
-    
     pub fn deinit(self: *TCKServer) void {
         if (self.client) |client| {
             client.deinit();
         }
     }
-    
     pub fn start(self: *TCKServer) !void {
         const address = try std.net.Address.parseIp("0.0.0.0", self.port);
-        
         var listener = address.listen(.{}) catch |err| switch (err) {
             error.AddressInUse => {
                 log.err("ERROR: Port {d} is already in use!", .{self.port});
@@ -59,37 +57,26 @@ pub const TCKServer = struct {
             },
         };
         defer listener.deinit();
-        
         log.info("SUCCESS: TCK Server listening on port {d}", .{self.port});
         log.info("LAUNCH: Ready to receive JSON-RPC requests", .{});
         log.info("INFO: Send JSON-RPC requests to http://localhost:{d}", .{self.port});
-        
         while (true) {
             const connection = try listener.accept();
             defer connection.stream.close();
-            
             try self.handleConnection(connection);
         }
     }
-    
     fn handleConnection(self: *TCKServer, connection: std.net.Server.Connection) !void {
-        // Read the HTTP request properly
-        var buffer: [10 * 1024 * 1024]u8 = undefined; // 10MB buffer
+        var buffer: [10 * 1024 * 1024]u8 = undefined; 
         var total_read: usize = 0;
         var headers_end: ?usize = null;
         var content_length: ?usize = null;
-        
-        // Read until we find the headers end
         while (headers_end == null and total_read < buffer.len) {
             const bytes_read = try connection.stream.read(buffer[total_read..]);
             if (bytes_read == 0) break;
             total_read += bytes_read;
-            
-            // Look for the end of headers
             if (std.mem.indexOf(u8, buffer[0..total_read], "\r\n\r\n")) |end_pos| {
                 headers_end = end_pos;
-                
-                // Parse Content-Length from headers
                 const headers = buffer[0..end_pos];
                 var lines = std.mem.splitSequence(u8, headers, "\r\n");
                 while (lines.next()) |line| {
@@ -102,21 +89,15 @@ pub const TCKServer = struct {
                 break;
             }
         }
-        
         if (headers_end == null) {
             try self.sendError(connection, "Invalid HTTP request - no headers end found");
             return;
         }
-        
         const headers_len = headers_end.? + 4;
         var body_len: usize = 0;
-        
-        // Calculate how much body we already have
         if (total_read > headers_len) {
             body_len = total_read - headers_len;
         }
-        
-        // Read remaining body if needed
         if (content_length) |expected_len| {
             while (body_len < expected_len and (headers_len + body_len) < buffer.len) {
                 const bytes_read = try connection.stream.read(buffer[headers_len + body_len..]);
@@ -124,17 +105,13 @@ pub const TCKServer = struct {
                 body_len += bytes_read;
             }
         }
-        
         if (body_len == 0) {
             try self.sendError(connection, "No request body found");
             return;
         }
-        
         const body = buffer[headers_len..headers_len + body_len];
         log.debug("Received raw request ({d} bytes total, {d} body bytes)", .{total_read, body_len});
         log.debug("Request body: {s}", .{body});
-        
-        // Parse JSON-RPC request
         var rpc_request = json_rpc.Request.parse(self.allocator, body) catch |err| {
             log.err("Failed to parse JSON-RPC request: {}", .{err});
             try self.sendJsonResponse(connection, json_rpc.Response.err(
@@ -146,18 +123,13 @@ pub const TCKServer = struct {
             return;
         };
         defer rpc_request.deinit(self.allocator);
-        
-        // Process the request
         const rpc_response = try self.processRequest(&rpc_request);
         defer {
             var resp = rpc_response;
             resp.deinit(self.allocator);
         }
-        
-        // Send response
         try self.sendJsonResponse(connection, rpc_response);
     }
-    
     fn processRequest(self: *TCKServer, request: *json_rpc.Request) !json_rpc.Response {
         const method = json_rpc.Method.fromString(request.method) orelse {
             log.warn("Method not found: {s}", .{request.method});
@@ -168,24 +140,16 @@ pub const TCKServer = struct {
                 request.id,
             );
         };
-        
         log.info("Processing method: {s}", .{request.method});
-        
-        // Route to appropriate service
         const result = switch (method) {
-            // SDK Service methods
             .setup => try sdk_service.setup(self.allocator, &self.client, request.params),
             .reset => try sdk_service.reset(self.allocator, &self.client, request.params),
-            
-            // Account Service methods
             .createAccount => try account_service.createAccount(self.allocator, self.client, request.params),
             .updateAccount => try account_service.updateAccount(self.allocator, self.client, request.params),
             .deleteAccount => try account_service.deleteAccount(self.allocator, self.client, request.params),
             .approveAllowance => try account_service.approveAllowance(self.allocator, self.client, request.params),
             .deleteAllowance => try account_service.deleteAllowance(self.allocator, self.client, request.params),
             .transferCrypto => try account_service.transferCrypto(self.allocator, self.client, request.params),
-            
-            // Token Service methods
             .createToken => try token_service.createToken(self.allocator, self.client, request.params),
             .updateToken => try token_service.updateToken(self.allocator, self.client, request.params),
             .deleteToken => try token_service.deleteToken(self.allocator, self.client, request.params),
@@ -205,37 +169,42 @@ pub const TCKServer = struct {
             .airdropToken => try token_service.airdropToken(self.allocator, self.client, request.params),
             .cancelAirdrop => try token_service.cancelAirdrop(self.allocator, self.client, request.params),
             .rejectToken => try token_service.rejectToken(self.allocator, self.client, request.params),
-            
-            // File Service methods
             .createFile => try file_service.createFile(self.allocator, self.client, request.params),
             .updateFile => try file_service.updateFile(self.allocator, self.client, request.params),
             .deleteFile => try file_service.deleteFile(self.allocator, self.client, request.params),
             .appendFile => try file_service.appendFile(self.allocator, self.client, request.params),
-            
-            // Topic Service methods
             .createTopic => try topic_service.createTopic(self.allocator, self.client, request.params),
             .updateTopic => try topic_service.updateTopic(self.allocator, self.client, request.params),
             .deleteTopic => try topic_service.deleteTopic(self.allocator, self.client, request.params),
             .submitTopicMessage => try topic_service.submitTopicMessage(self.allocator, self.client, request.params),
-            
-            // Contract Service methods
             .createContract => try contract_service.createContract(self.allocator, self.client, request.params),
             .updateContract => try contract_service.updateContract(self.allocator, self.client, request.params),
             .deleteContract => try contract_service.deleteContract(self.allocator, self.client, request.params),
             .executeContract => try contract_service.executeContract(self.allocator, self.client, request.params),
-            
-            // Key Service methods
             .generateKey => try key_service.generateKey(self.allocator, request.params),
+            .createSchedule => try schedule_service.createSchedule(self.allocator, self.client, request.params),
+            .signSchedule => try schedule_service.signSchedule(self.allocator, self.client, request.params),
+            .deleteSchedule => try schedule_service.deleteSchedule(self.allocator, self.client, request.params),
+            .getScheduleInfo => try schedule_service.getScheduleInfo(self.allocator, self.client, request.params),
+            .createNode => try node_service.createNode(self.allocator, self.client, request.params),
+            .updateNode => try node_service.updateNode(self.allocator, self.client, request.params),
+            .deleteNode => try node_service.deleteNode(self.allocator, self.client, request.params),
+            .getAccountInfo => try query_service.getAccountInfo(self.allocator, self.client, request.params),
+            .getAccountBalance => try query_service.getAccountBalance(self.allocator, self.client, request.params),
+            .getTokenInfo => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
+            .getTokenBalance => try query_service.getTokenBalance(self.allocator, self.client, request.params),
+            .getFileInfo => try query_service.getFileInfo(self.allocator, self.client, request.params),
+            .getFileContents => try query_service.getFileContents(self.allocator, self.client, request.params),
+            .getTopicInfo => try query_service.getTopicInfo(self.allocator, self.client, request.params),
+            .getContractInfo => try query_service.getContractInfo(self.allocator, self.client, request.params),
+            .getTransactionRecord => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
+            .getTransactionReceipt => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
         };
-        
         return json_rpc.Response.success(self.allocator, result, request.id);
     }
-    
     fn sendJsonResponse(self: *TCKServer, connection: std.net.Server.Connection, rpc_response: json_rpc.Response) !void {
         const json_str = try rpc_response.stringify(self.allocator);
         defer self.allocator.free(json_str);
-        
-        // Create HTTP response
         const http_response = try std.fmt.allocPrint(self.allocator,
             "HTTP/1.1 200 OK\r\n" ++
             "Content-Type: application/json\r\n" ++
@@ -249,12 +218,9 @@ pub const TCKServer = struct {
             .{ json_str.len, json_str }
         );
         defer self.allocator.free(http_response);
-        
         _ = try connection.stream.writeAll(http_response);
-        
         log.debug("Sent response: {s}", .{json_str});
     }
-    
     fn sendError(self: *TCKServer, connection: std.net.Server.Connection, message: []const u8) !void {
         const http_response = try std.fmt.allocPrint(self.allocator,
             "HTTP/1.1 400 Bad Request\r\n" ++
@@ -266,29 +232,21 @@ pub const TCKServer = struct {
             .{ message.len, message }
         );
         defer self.allocator.free(http_response);
-        
         _ = try connection.stream.writeAll(http_response);
-        
         log.debug("Sent error: {s}", .{message});
     }
 };
-
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
-    
-    // Get port from environment or use default
     const port_str = std.process.getEnvVarOwned(allocator, "TCK_PORT") catch "8544";
     defer if (!std.mem.eql(u8, port_str, "8544")) allocator.free(port_str);
     const port = try std.fmt.parseInt(u16, port_str, 10);
-    
     log.info("Starting TCK Server", .{});
     log.info("Version: 1.0.0", .{});
-    
     var server = TCKServer.init(allocator, port);
     defer server.deinit();
-    
     server.start() catch |err| switch (err) {
         error.PortAlreadyInUse => {
             log.err(" Cannot start TCK server - port {d} is already in use.", .{port});

--- a/tck/utils/utils.zig
+++ b/tck/utils/utils.zig
@@ -1,97 +1,60 @@
 const std = @import("std");
 const hedera = @import("hedera");
 const json = std.json;
-
-// Parse account ID from string (format: "0.0.123")
 pub fn parseAccountId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.AccountId {
     return try hedera.AccountId.fromString(allocator, id_str);
 }
-
-// Parse token ID from string (format: "0.0.456")
 pub fn parseTokenId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.TokenId {
     return try hedera.TokenId.fromString(allocator, id_str);
 }
-
-// Parse topic ID from string (format: "0.0.789")
 pub fn parseTopicId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.TopicId {
     return try hedera.TopicId.fromString(allocator, id_str);
 }
-
-// Parse file ID from string (format: "0.0.111")
 pub fn parseFileId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.FileId {
     return try hedera.FileId.fromString(allocator, id_str);
 }
-
-// Parse contract ID from string (format: "0.0.222")
 pub fn parseContractId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.ContractId {
     return try hedera.ContractId.fromString(allocator, id_str);
 }
-
-// Parse schedule ID from string (format: "0.0.333")
 pub fn parseScheduleId(allocator: std.mem.Allocator, id_str: []const u8) !hedera.ScheduleId {
     return try hedera.ScheduleId.fromString(allocator, id_str);
 }
-
-// Parse private key from string
 pub fn parsePrivateKey(allocator: std.mem.Allocator, key_str: []const u8) !hedera.PrivateKey {
     return try hedera.PrivateKey.fromString(allocator, key_str);
 }
-
-// Parse public key from string
 pub fn parsePublicKey(allocator: std.mem.Allocator, key_str: []const u8) !hedera.PublicKey {
     return try hedera.PublicKey.fromString(allocator, key_str);
 }
-
-// Parse key (simplified for now - just string keys)
-pub fn parseKey(allocator: std.mem.Allocator, key_value: json.Value) !hedera.Key {
-    switch (key_value) {
-        .string => |key_str| {
-            // Try to parse as public key first
-            if (hedera.PublicKey.fromString(allocator, key_str)) |pub_key| {
-                return hedera.Key.fromPublicKey(pub_key);
-            } else |_| {
-                // Try private key
-                const priv_key = try hedera.PrivateKey.fromString(allocator, key_str);
-                defer priv_key.deinit();
-                return hedera.Key.fromPublicKey(priv_key.getPublicKey());
-            }
-        },
-        else => return error.InvalidKeyType,
+pub fn parseKey(allocator: std.mem.Allocator, key_str: []const u8) !hedera.Key {
+    if (hedera.PublicKey.fromString(allocator, key_str)) |pub_key| {
+        return hedera.Key.fromPublicKey(pub_key);
+    } else |_| {
+        var priv_key = try hedera.PrivateKey.fromString(allocator, key_str);
+        defer priv_key.deinit();
+        return hedera.Key.fromPublicKey(priv_key.getPublicKey());
     }
 }
-
-// Parse duration from seconds string
 pub fn parseDuration(seconds_str: []const u8) !hedera.Duration {
     const seconds = try std.fmt.parseInt(i64, seconds_str, 10);
     return hedera.Duration.fromSeconds(seconds);
 }
-
-// Parse timestamp from seconds string
 pub fn parseTimestamp(seconds_str: []const u8) !hedera.Timestamp {
     const seconds = try std.fmt.parseInt(i64, seconds_str, 10);
     return hedera.Timestamp.fromSeconds(seconds);
 }
-
-// Parse Hbar amount from tinybar string
 pub fn parseHbar(tinybar_str: []const u8) !hedera.Hbar {
     const tinybars = try std.fmt.parseInt(i64, tinybar_str, 10);
     return try hedera.Hbar.fromTinybars(tinybars);
 }
-
-// Helper to split ID string
 fn splitIdString(allocator: std.mem.Allocator, id_str: []const u8) ![][]const u8 {
     var parts = std.ArrayList([]const u8).init(allocator);
     defer parts.deinit();
-    
     var it = std.mem.tokenize(u8, id_str, ".");
     while (it.next()) |part| {
         try parts.append(part);
     }
-    
     return try parts.toOwnedSlice();
 }
-
-// Extract string from JSON value
 pub fn getString(value: json.Value, key: []const u8) ?[]const u8 {
     switch (value) {
         .object => |obj| {
@@ -106,8 +69,6 @@ pub fn getString(value: json.Value, key: []const u8) ?[]const u8 {
     }
     return null;
 }
-
-// Extract integer from JSON value
 pub fn getInt(value: json.Value, key: []const u8) ?i64 {
     switch (value) {
         .object => |obj| {
@@ -122,8 +83,6 @@ pub fn getInt(value: json.Value, key: []const u8) ?i64 {
     }
     return null;
 }
-
-// Extract boolean from JSON value
 pub fn getBool(value: json.Value, key: []const u8) ?bool {
     switch (value) {
         .object => |obj| {
@@ -138,21 +97,78 @@ pub fn getBool(value: json.Value, key: []const u8) ?bool {
     }
     return null;
 }
-
-// Create response with status and additional fields
 pub fn createResponse(allocator: std.mem.Allocator, status: []const u8, fields: ?json.ObjectMap) !json.Value {
     var response_obj = json.ObjectMap.init(allocator);
-    
-    // Add status field
     try response_obj.put("status", json.Value{ .string = try allocator.dupe(u8, status) });
-    
-    // Add additional fields if provided
     if (fields) |field_map| {
         var iterator = field_map.iterator();
         while (iterator.next()) |entry| {
             try response_obj.put(entry.key_ptr.*, entry.value_ptr.*);
         }
     }
-    
     return json.Value{ .object = response_obj };
+}
+pub fn createErrorMap(allocator: std.mem.Allocator, message: []const u8) !json.ObjectMap {
+    var error_map = json.ObjectMap.init(allocator);
+    try error_map.put("error", json.Value{ .string = message });
+    return error_map;
+}
+pub fn getStringParam(value: json.Value, key: []const u8) ![]const u8 {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .string => |s| return s,
+            else => return error.InvalidParameterType,
+        }
+    }
+    return error.MissingParameter;
+}
+pub fn getOptionalStringParam(value: json.Value, key: []const u8) !?[]const u8 {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .string => |s| return s,
+            .null => return null,
+            else => return error.InvalidParameterType,
+        }
+    }
+    return null;
+}
+pub fn getNumberParam(value: json.Value, key: []const u8) !i64 {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .integer => |i| return i,
+            .float => |f| return @intFromFloat(f),
+            else => return error.InvalidParameterType,
+        }
+    }
+    return error.MissingParameter;
+}
+pub fn getOptionalNumberParam(value: json.Value, key: []const u8) !?i64 {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .integer => |i| return i,
+            .float => |f| return @intFromFloat(f),
+            .null => return null,
+            else => return error.InvalidParameterType,
+        }
+    }
+    return null;
+}
+pub fn getBoolParam(value: json.Value, key: []const u8) !bool {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .bool => |b| return b,
+            else => return error.InvalidParameterType,
+        }
+    }
+    return error.MissingParameter;
+}
+pub fn getOptionalBoolParam(value: json.Value, key: []const u8) !?bool {
+    if (value.object.get(key)) |param| {
+        switch (param) {
+            .bool => |b| return b,
+            .null => return null,
+            else => return error.InvalidParameterType,
+        }
+    }
+    return null;
 }

--- a/tests/integration/integration_test.zig
+++ b/tests/integration/integration_test.zig
@@ -242,7 +242,7 @@ test "Topic operations" {
     _ = try topic_create.setSubmitKey(hedera.Key.fromPublicKey(admin_key.getPublicKey()));
 
     // Topic message submit
-    var message_submit = try hedera.TopicMessageSubmitTransaction.init(allocator);
+    var message_submit = hedera.TopicMessageSubmitTransaction.init(allocator);
     defer message_submit.deinit();
 
     const topic_id = hedera.TopicId.init(0, 0, 888);

--- a/tests/unit/contract_test.zig
+++ b/tests/unit/contract_test.zig
@@ -259,7 +259,7 @@ test "Contract creation transaction" {
     _ = try tx.setAdminKey(hedera.Key.fromPublicKey(admin_key.getPublicKey()));
     
     // Set memo
-    _ = try tx.setMemo("Test Contract");
+    _ = try tx.setContractMemo("Test Contract");
     
     // Set auto renew
     _ = try tx.setAutoRenewPeriod(hedera.Duration.fromDays(90));

--- a/tests/unit/query_test.zig
+++ b/tests/unit/query_test.zig
@@ -457,7 +457,7 @@ test "Query builder pattern" {
     // Verify all settings
     try testing.expectEqual(@as(u64, 1234), query.account_id.?.account);
     try testing.expectEqual(@as(i64, 100_000_000), query.payment().?.toTinybars());
-    try testing.expectEqual(@as(u32, 3), query.max_retry());
+    try testing.expectEqual(@as(u32, 3), query.maxRetry());
     try testing.expectEqual(@as(i64, 8), query.max_backoff.seconds);
 }
 

--- a/tests/unit/token_test.zig
+++ b/tests/unit/token_test.zig
@@ -55,7 +55,7 @@ test "Token create transaction" {
     _ = try tx.setMaxSupply(0);
     _ = try tx.setFreezeDefault(false);
     _ = try tx.setExpirationTime(hedera.Timestamp.fromSeconds(1234567890));
-    _ = try tx.setAutoRenewAccount(hedera.AccountId.init(0, 0, 200));
+    _ = try tx.setAutoRenewAccountId(hedera.AccountId.init(0, 0, 200));
     _ = try tx.setAutoRenewPeriod(hedera.Duration.fromDays(90));
     
     // Custom fees removed temporarily - structure needs alignment

--- a/tests/unit/topic_test.zig
+++ b/tests/unit/topic_test.zig
@@ -97,7 +97,7 @@ test "Topic message submit transaction" {
     defer arena.deinit();
     const allocator = arena.allocator();
     
-    var tx = try hedera.TopicMessageSubmitTransaction.init(allocator);
+    var tx = hedera.TopicMessageSubmitTransaction.init(allocator);
     defer tx.deinit();
     
     // Set topic ID
@@ -125,7 +125,7 @@ test "Topic message chunking" {
     defer arena.deinit();
     const allocator = arena.allocator();
     
-    var tx = try hedera.TopicMessageSubmitTransaction.init(allocator);
+    var tx = hedera.TopicMessageSubmitTransaction.init(allocator);
     defer tx.deinit();
     
     // Set topic ID


### PR DESCRIPTION
  This commit introduces a major refactoring of the query and transaction submission logic to improve robustness,
  extensibility, and alignment with the Hedera protobuf definitions. The Technology Compatibility Kit (TCK) has also been
  significantly expanded with new service methods.

  Key changes include:

   - Query/Transaction Refactoring:
     - Centralized gRPC service and method routing within Query and Transaction base structs.
     - Transactions and queries now build their own protobuf bodies, ensuring correct field numbers and types. - Replaced generic Query.execute with Query.executeWithBytes for more direct control over the payload. - The freezeWith method on transactions now consistently returns a pointer to the transaction.

   - TCK Expansion: - Added new TCK service methods for Schedule, Node, and various queries (getAccountInfo, getAccountBalance, etc.). - Simplified TCK service method implementations, removing boilerplate code. - Cleaned up and simplified the main build.zig file, removing the example builds.

   - API Improvements:
     - Removed deprecated fields like proxy_account_id.
     - Standardized function naming (e.g., maxRetry instead of max_retry). - Refactored TopicCreateTransaction and TopicMessageSubmitTransaction to be more consistent with other transaction types.

   - New Features: - Added CostQuery for estimating transaction fees. - Introduced AbstractTokenTransferTransaction to handle common token transfer logic.

  This refactoring lays the groundwork for more comprehensive TCK coverage and a more maintainable SDK core.