### PR TITLE
feat: Refactor query and transaction handling and expand TCK

### DIFF
--- a/src/query/receipt_query.zig
+++ b/src/query/receipt_query.zig
@@ -281,7 +281,12 @@ pub const TransactionReceiptQuery = struct {
                                         1 => {
                                             const current_bytes = try rate_reader.readMessage();
                                             var current_reader = ProtoReader.init(current_bytes);
-                                            receipt.exchange_rate = try ExchangeRate.decode(&current_reader);
+                                            const local_rate = try ExchangeRate.decode(&current_reader);
+                                            receipt.exchange_rate = @import("../core/exchange_rate.zig").ExchangeRate{
+                                                .cent_equivalent = local_rate.cents,
+                                                .hbar_equivalent = local_rate.hbars,
+                                                .expiration_time = null,
+                                            };
                                         },
                                         else => try rate_reader.skipField(rate_tag.wire_type),
                                     }

--- a/src/query/transaction_record_query.zig
+++ b/src/query/transaction_record_query.zig
@@ -9,11 +9,9 @@ const ProtoWriter = @import("../protobuf/encoding.zig").ProtoWriter;
 const ProtoReader = @import("../protobuf/encoding.zig").ProtoReader;
 const Hbar = @import("../core/hbar.zig").Hbar;
 const Transfer = @import("../transfer/transfer_transaction.zig").Transfer;
-const TokenTransfer = @import("../transfer/transfer_transaction.zig").TokenTransfer;
 const NftTransfer = @import("../transfer/transfer_transaction.zig").NftTransfer;
+const TokenTransfer = @import("../transaction/transaction_record.zig").TokenTransfer;
 const TransactionReceipt = @import("receipt_query.zig").TransactionReceipt;
-
-
 
 // Use the consolidated TransactionRecord from transaction module
 pub const TransactionRecord = @import("../transaction/transaction_record.zig").TransactionRecord;
@@ -25,7 +23,7 @@ pub const TransactionRecordQuery = struct {
     transaction_id: ?TransactionId,
     include_children: bool,
     include_duplicates: bool,
-    
+
     pub fn init(allocator: std.mem.Allocator) TransactionRecordQuery {
         return TransactionRecordQuery{
             .base = Query.init(allocator),
@@ -34,54 +32,54 @@ pub const TransactionRecordQuery = struct {
             .include_duplicates = false,
         };
     }
-    
+
     pub fn deinit(self: *TransactionRecordQuery) void {
         self.base.deinit();
     }
-    
+
     // Set the transaction ID to query
     pub fn setTransactionId(self: *TransactionRecordQuery, id: TransactionId) !*TransactionRecordQuery {
         self.transaction_id = id;
         return self;
     }
-    
+
     // Include child transaction records
     pub fn setIncludeChildren(self: *TransactionRecordQuery, include: bool) !*TransactionRecordQuery {
         self.include_children = include;
         return self;
     }
-    
+
     // Alias for setIncludeChildren to match TransactionResponse usage
     pub fn setIncludeChildRecords(self: *TransactionRecordQuery, include: bool) !*TransactionRecordQuery {
         return self.setIncludeChildren(include);
     }
-    
+
     // Include duplicate transaction records
     pub fn setIncludeDuplicates(self: *TransactionRecordQuery, include: bool) !*TransactionRecordQuery {
         self.include_duplicates = include;
         return self;
     }
-    
+
     // Execute the query
     pub fn execute(self: *TransactionRecordQuery, client: *Client) !TransactionRecord {
         if (self.transaction_id == null) {
             return error.TransactionIdRequired;
         }
-        
+
         const response = try self.base.execute(client);
         return try self.parseResponse(response);
     }
-    
+
     // Get cost of the query
     pub fn getCost(self: *TransactionRecordQuery, client: *Client) !Hbar {
         self.base.response_type = .CostAnswer;
         const response = try self.base.execute(client);
-        
+
         var reader = ProtoReader.init(response.response_bytes);
-        
+
         while (reader.hasMore()) {
             const tag = try reader.readTag();
-            
+
             switch (tag.field_number) {
                 2 => {
                     const cost = try reader.readUint64();
@@ -90,98 +88,98 @@ pub const TransactionRecordQuery = struct {
                 else => try reader.skipField(tag.wire_type),
             }
         }
-        
+
         return error.CostNotFound;
     }
-    
+
     // Build the query
     fn buildQuery(self: *TransactionRecordQuery) ![]u8 {
         var writer = ProtoWriter.init(self.base.allocator);
         defer writer.deinit();
-        
+
         // Query header
         var header_writer = ProtoWriter.init(self.base.allocator);
         defer header_writer.deinit();
-        
+
         if (self.base.payment_transaction) |payment| {
             try header_writer.writeMessage(1, payment);
         }
-        
+
         try header_writer.writeInt32(2, @intFromEnum(self.base.response_type));
-        
+
         const header_bytes = try header_writer.toOwnedSlice();
         defer self.base.allocator.free(header_bytes);
         try writer.writeMessage(1, header_bytes);
-        
+
         // TransactionGetRecord query
         var record_query_writer = ProtoWriter.init(self.base.allocator);
         defer record_query_writer.deinit();
-        
+
         if (self.transaction_id) |tx_id| {
             var tx_id_writer = ProtoWriter.init(self.base.allocator);
             defer tx_id_writer.deinit();
-            
+
             // Write account ID
             var account_writer = ProtoWriter.init(self.base.allocator);
             defer account_writer.deinit();
             try account_writer.writeInt64(1, @intCast(tx_id.account_id.shard));
             try account_writer.writeInt64(2, @intCast(tx_id.account_id.realm));
             try account_writer.writeInt64(3, @intCast(tx_id.account_id.account));
-            
+
             const account_bytes = try account_writer.toOwnedSlice();
             defer self.base.allocator.free(account_bytes);
             try tx_id_writer.writeMessage(1, account_bytes);
-            
+
             // Write valid start timestamp
             var timestamp_writer = ProtoWriter.init(self.base.allocator);
             defer timestamp_writer.deinit();
             try timestamp_writer.writeInt64(1, tx_id.valid_start.seconds);
             try timestamp_writer.writeInt32(2, tx_id.valid_start.nanos);
-            
+
             const timestamp_bytes = try timestamp_writer.toOwnedSlice();
             defer self.base.allocator.free(timestamp_bytes);
             try tx_id_writer.writeMessage(2, timestamp_bytes);
-            
+
             if (tx_id.scheduled) {
                 try tx_id_writer.writeBool(3, true);
             }
-            
+
             if (tx_id.nonce) |nonce| {
                 try tx_id_writer.writeInt32(4, @intCast(nonce));
             }
-            
+
             const tx_id_bytes = try tx_id_writer.toOwnedSlice();
             defer self.base.allocator.free(tx_id_bytes);
             try record_query_writer.writeMessage(1, tx_id_bytes);
         }
-        
+
         if (self.include_children) {
             try record_query_writer.writeBool(2, true);
         }
-        
+
         if (self.include_duplicates) {
             try record_query_writer.writeBool(3, true);
         }
-        
+
         const record_query_bytes = try record_query_writer.toOwnedSlice();
         defer self.base.allocator.free(record_query_bytes);
         try writer.writeMessage(11, record_query_bytes); // transactionGetRecord field
-        
+
         return writer.toOwnedSlice();
     }
-    
+
     // Parse the response
     fn parseResponse(self: *TransactionRecordQuery, response: QueryResponse) !TransactionRecord {
         try response.validateStatus();
-        
+
         var reader = ProtoReader.init(response.response_bytes);
         const receipt = TransactionReceipt.init(self.base.allocator, .OK);
         const tx_id = self.transaction_id orelse TransactionId.generate(AccountId.init(0, 0, 0));
         var record = TransactionRecord.init(self.base.allocator, receipt, tx_id);
-        
+
         while (reader.hasMore()) {
             const tag = try reader.readTag();
-            
+
             switch (tag.field_number) {
                 1 => {
                     // Transaction receipt
@@ -243,9 +241,25 @@ pub const TransactionRecordQuery = struct {
                 },
                 9 => {
                     // Token transfer lists
-                    const token_transfer_bytes = try reader.readBytes();
-                    const token_transfer = try TokenTransfer.fromProtobuf(self.base.allocator, token_transfer_bytes);
-                    try record.token_transfers.append(token_transfer);
+                    const token_list_bytes = try reader.readBytes();
+                    var list_reader = ProtoReader.init(token_list_bytes);
+
+                    while (list_reader.hasMore()) {
+                        const list_tag = try list_reader.readTag();
+                        switch (list_tag.field_number) {
+                            1 => {
+                                // Token ID
+                                _ = try list_reader.readBytes();
+                            },
+                            2 => {
+                                // Transfers
+                                const transfer_bytes = try list_reader.readBytes();
+                                const token_transfer = try TokenTransfer.fromProtobuf(self.base.allocator, transfer_bytes);
+                                try record.token_transfers.append(token_transfer);
+                            },
+                            else => try list_reader.skipField(list_tag.wire_type),
+                        }
+                    }
                 },
                 10 => {
                     // Schedule ref
@@ -257,59 +271,110 @@ pub const TransactionRecordQuery = struct {
                             3 => {
                                 // Schedule ID
                                 const schedule_id_bytes = try schedule_reader.readBytes();
-                                record.schedule_ref = try @import("../core/id.zig").ScheduleId.fromProtobuf(schedule_id_bytes);
+                                record.schedule_ref = try @import("../core/id.zig").ScheduleId.fromProtobuf(self.base.allocator, schedule_id_bytes);
                             },
                             else => try schedule_reader.skipField(schedule_tag.wire_type),
                         }
                     }
                 },
                 11 => {
-                    // Assessed custom fees
                     const fee_bytes = try reader.readBytes();
+                    var fee_list = std.ArrayList(@import("../transaction/transaction_record.zig").AssessedCustomFee).init(self.base.allocator);
+                    defer fee_list.deinit();
+                    
                     var fee_reader = ProtoReader.init(fee_bytes);
+                    var fee = @import("../transaction/transaction_record.zig").AssessedCustomFee{
+                        .amount = 0,
+                        .token_id = null,
+                        .fee_collector_account_id = AccountId.init(0, 0, 0),
+                        .payer_account_ids = &[_]AccountId{},
+                    };
+                    
                     while (fee_reader.hasMore()) {
                         const fee_tag = try fee_reader.readTag();
                         switch (fee_tag.field_number) {
-                            1 => {
-                                const amount = try fee_reader.readInt64();
-                                record.assessed_custom_fees_amount = @intCast(amount);
+                            1 => fee.amount = try fee_reader.readInt64(),
+                            2 => {
+                                const token_bytes = try fee_reader.readBytes();
+                                fee.token_id = try @import("../core/id.zig").TokenId.fromProtobuf(self.base.allocator, token_bytes);
+                            },
+                            3 => {
+                                const collector_bytes = try fee_reader.readBytes();
+                                fee.fee_collector_account_id = try AccountId.fromProtobuf(self.base.allocator, collector_bytes);
+                            },
+                            4 => {
+                                const payer_bytes = try fee_reader.readBytes();
+                                var payers = std.ArrayList(AccountId).init(self.base.allocator);
+                                const payer = try AccountId.fromProtobuf(self.base.allocator, payer_bytes);
+                                try payers.append(payer);
+                                fee.payer_account_ids = try payers.toOwnedSlice();
                             },
                             else => try fee_reader.skipField(fee_tag.wire_type),
                         }
                     }
+                    
+                    try fee_list.append(fee);
+                    record.assessed_custom_fees = try fee_list.toOwnedSlice();
                 },
                 12 => {
-                    // NFT transfers
                     const nft_transfer_bytes = try reader.readBytes();
-                    const nft_transfer = try NftTransfer.fromProtobuf(self.base.allocator, nft_transfer_bytes);
-                    try record.nft_transfers.append(nft_transfer);
+                    var nft_list_reader = ProtoReader.init(nft_transfer_bytes);
+                    
+                    while (nft_list_reader.hasMore()) {
+                        const nft_tag = try nft_list_reader.readTag();
+                        switch (nft_tag.field_number) {
+                            1 => {
+                                _ = try nft_list_reader.readBytes();
+                            },
+                            2 => {
+                                const transfer_bytes = try nft_list_reader.readBytes();
+                                const nft_transfer = try NftTransfer.fromProtobuf(self.base.allocator, transfer_bytes);
+                                const token_nft = @import("../transaction/transaction_record.zig").TokenNftTransfer{
+                                    .sender_account_id = nft_transfer.sender_account_id,
+                                    .receiver_account_id = nft_transfer.receiver_account_id,
+                                    .serial_number = @intCast(nft_transfer.nft_id.serial_number),
+                                    .is_approval = nft_transfer.is_approved,
+                                };
+                                try record.nft_transfers.append(token_nft);
+                            },
+                            else => try nft_list_reader.skipField(nft_tag.wire_type),
+                        }
+                    }
                 },
                 13 => {
-                    // Automatic token associations
                     const assoc_bytes = try reader.readBytes();
+                    var assoc_list = std.ArrayList(@import("../transaction/transaction_record.zig").TokenAssociation).init(self.base.allocator);
+                    defer assoc_list.deinit();
+                    
                     var assoc_reader = ProtoReader.init(assoc_bytes);
+                    var assoc = @import("../transaction/transaction_record.zig").TokenAssociation{
+                        .token_id = @import("../core/id.zig").TokenId.init(0, 0, 0),
+                        .account_id = AccountId.init(0, 0, 0),
+                    };
+                    
                     while (assoc_reader.hasMore()) {
                         const assoc_tag = try assoc_reader.readTag();
                         switch (assoc_tag.field_number) {
                             1 => {
-                                const account_bytes = try assoc_reader.readBytes();
-                                const account_id = try AccountId.fromProtobuf(account_bytes);
-                                try record.automatic_token_associations.append(account_id);
+                                const token_bytes = try assoc_reader.readBytes();
+                                assoc.token_id = try @import("../core/id.zig").TokenId.fromProtobuf(self.base.allocator, token_bytes);
                             },
                             2 => {
-                                const token_bytes = try assoc_reader.readBytes();
-                                const token_id = try @import("../core/id.zig").TokenId.fromProtobuf(token_bytes);
-                                _ = token_id;
+                                const account_bytes = try assoc_reader.readBytes();
+                                assoc.account_id = try AccountId.fromProtobuf(self.base.allocator, account_bytes);
                             },
                             else => try assoc_reader.skipField(assoc_tag.wire_type),
                         }
                     }
+                    
+                    try assoc_list.append(assoc);
+                    record.automatic_token_associations = try assoc_list.toOwnedSlice();
                 },
                 14 => {
                     // Parent consensus timestamp
                     const parent_timestamp_bytes = try reader.readBytes();
                     var parent_reader = ProtoReader.init(parent_timestamp_bytes);
-                    var parent_timestamp = Timestamp{};
+                    var parent_timestamp = Timestamp{ .seconds = 0, .nanos = 0 };
                     while (parent_reader.hasMore()) {
                         const parent_tag = try parent_reader.readTag();
                         switch (parent_tag.field_number) {
@@ -321,15 +386,16 @@ pub const TransactionRecordQuery = struct {
                     record.parent_consensus_timestamp = parent_timestamp;
                 },
                 15 => {
-                    // Alias
-                    record.alias = try reader.readBytes();
+                    const alias_bytes = try reader.readBytes();
+                    if (alias_bytes.len > 0) {
+                        record.alias_key = try @import("../crypto/key.zig").PublicKey.fromProtobuf(self.base.allocator, alias_bytes);
+                    }
                 },
                 16 => {
                     // Ethereum hash
                     record.ethereum_hash = try reader.readBytes();
                 },
                 17 => {
-                    // Staking reward transfers
                     const staking_bytes = try reader.readBytes();
                     var staking_reader = ProtoReader.init(staking_bytes);
                     while (staking_reader.hasMore()) {
@@ -338,7 +404,7 @@ pub const TransactionRecordQuery = struct {
                             1 => {
                                 const account_amount_bytes = try staking_reader.readBytes();
                                 const transfer = try Transfer.fromProtobuf(self.base.allocator, account_amount_bytes);
-                                try record.paid_staking_rewards.append(transfer);
+                                try record.paid_staking_rewards.put(transfer.account_id, transfer.amount);
                             },
                             else => try staking_reader.skipField(staking_tag.wire_type),
                         }
@@ -349,33 +415,32 @@ pub const TransactionRecordQuery = struct {
                     record.evm_address = try reader.readBytes();
                 },
                 19 => {
-                    // Child transaction IDs
-                    const child_tx_bytes = try reader.readBytes();
-                    const child_tx_id = try TransactionId.fromProtobuf(self.base.allocator, child_tx_bytes);
-                    try record.child_transaction_ids.append(child_tx_id);
+                    _ = try reader.readBytes();
                 },
                 20 => {
-                    // Child transaction records
-                    const child_record_bytes = try reader.readBytes();
-                    const child_record = try parseChildRecord(self.base.allocator, child_record_bytes);
-                    try record.child_transaction_records.append(child_record);
+                    const child_bytes = try reader.readBytes();
+                    var child_list = std.ArrayList(TransactionRecord).init(self.base.allocator);
+                    defer child_list.deinit();
+                    const child_record = try parseChildRecord(self.base.allocator, child_bytes);
+                    try child_list.append(child_record);
+                    record.children = try child_list.toOwnedSlice();
                 },
                 else => try reader.skipField(tag.wire_type),
             }
         }
-        
+
         return record;
     }
-    
+
     fn parseChildRecord(allocator: std.mem.Allocator, bytes: []const u8) !TransactionRecord {
         var reader = ProtoReader.init(bytes);
-        const receipt = TransactionReceipt.init(allocator);
+        const receipt = TransactionReceipt.init(allocator, @import("../core/status.zig").Status.OK);
         const tx_id = TransactionId.generate(AccountId.init(0, 0, 0));
         var record = TransactionRecord.init(allocator, receipt, tx_id);
-        
+
         while (reader.hasMore()) {
             const tag = try reader.readTag();
-            
+
             switch (tag.field_number) {
                 1 => {
                     const receipt_bytes = try reader.readBytes();
@@ -403,7 +468,7 @@ pub const TransactionRecordQuery = struct {
                 else => try reader.skipField(tag.wire_type),
             }
         }
-        
+
         return record;
     }
 };

--- a/tck/server.zig
+++ b/tck/server.zig
@@ -191,14 +191,14 @@ pub const TCKServer = struct {
             .deleteNode => try node_service.deleteNode(self.allocator, self.client, request.params),
             .getAccountInfo => try query_service.getAccountInfo(self.allocator, self.client, request.params),
             .getAccountBalance => try query_service.getAccountBalance(self.allocator, self.client, request.params),
-            .getTokenInfo => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
+            .getTokenInfo => try query_service.getTokenInfo(self.allocator, self.client, request.params),
             .getTokenBalance => try query_service.getTokenBalance(self.allocator, self.client, request.params),
             .getFileInfo => try query_service.getFileInfo(self.allocator, self.client, request.params),
             .getFileContents => try query_service.getFileContents(self.allocator, self.client, request.params),
             .getTopicInfo => try query_service.getTopicInfo(self.allocator, self.client, request.params),
             .getContractInfo => try query_service.getContractInfo(self.allocator, self.client, request.params),
-            .getTransactionRecord => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
-            .getTransactionReceipt => std.json.Value{ .object = try utils.createErrorMap(self.allocator, "Not implemented") },
+            .getTransactionRecord => try query_service.getTransactionRecord(self.allocator, self.client, request.params),
+            .getTransactionReceipt => try query_service.getTransactionReceipt(self.allocator, self.client, request.params),
         };
         return json_rpc.Response.success(self.allocator, result, request.id);
     }


### PR DESCRIPTION
  This commit introduces a major refactoring of the query and transaction submission logic to improve robustness,
  extensibility, and alignment with the Hedera protobuf definitions. The Technology Compatibility Kit (TCK) has also been
  significantly expanded with new service methods.

  Key changes include:

   - Query/Transaction Refactoring:
     - Centralized gRPC service and method routing within Query and Transaction base structs.
     - Transactions and queries now build their own protobuf bodies, ensuring correct field numbers and types. - Replaced generic Query.execute with Query.executeWithBytes for more direct control over the payload. - The freezeWith method on transactions now consistently returns a pointer to the transaction.

   - TCK Expansion: - Added new TCK service methods for Schedule, Node, and various queries (getAccountInfo, getAccountBalance, etc.). - Simplified TCK service method implementations, removing boilerplate code. - Cleaned up and simplified the main build.zig file, removing the example builds.

   - API Improvements:
     - Removed deprecated fields like proxy_account_id.
     - Standardized function naming (e.g., maxRetry instead of max_retry). - Refactored TopicCreateTransaction and TopicMessageSubmitTransaction to be more consistent with other transaction types.

   - New Features: - Added CostQuery for estimating transaction fees. - Introduced AbstractTokenTransferTransaction to handle common token transfer logic.