### PR TITLE
feat: Refactor query and transaction handling and expand TCK

### DIFF
--- a/src/hedera.zig
+++ b/src/hedera.zig
@@ -634,7 +634,7 @@ pub fn topicDeleteTransaction(allocator: std.mem.Allocator) !*TopicDeleteTransac
     return TopicDeleteTransaction.init(allocator);
 }
 
-pub fn topicMessageSubmitTransaction(allocator: std.mem.Allocator) !*TopicMessageSubmitTransaction {
+pub fn topicMessageSubmitTransaction(allocator: std.mem.Allocator) TopicMessageSubmitTransaction {
     return TopicMessageSubmitTransaction.init(allocator);
 }
 

--- a/tck/methods/contract_service.zig
+++ b/tck/methods/contract_service.zig
@@ -58,17 +58,119 @@ pub fn createContract(allocator: std.mem.Allocator, client: ?*hedera.Client, par
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
 pub fn updateContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const contract_id_str = utils.getString(p, "contractId") orelse return error.MissingContractId;
+    const contract_id = try utils.parseContractId(allocator, contract_id_str);
+    
+    var tx = hedera.contractUpdateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setContractId(contract_id);
+    
+    if (utils.getString(p, "adminKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setAdminKey(key);
+    }
+    
+    if (utils.getString(p, "expirationTime")) |exp_str| {
+        const timestamp = try utils.parseTimestamp(exp_str);
+        _ = try tx.setExpirationTime(timestamp);
+    }
+    
+    if (utils.getString(p, "contractMemo")) |memo| {
+        _ = try tx.setContractMemo(memo);
+    }
+    
+    if (utils.getString(p, "autoRenewPeriod")) |period_str| {
+        const duration = try utils.parseDuration(period_str);
+        _ = try tx.setAutoRenewPeriod(duration);
+    }
+    
+    if (utils.getString(p, "autoRenewAccountId")) |auto_renew_str| {
+        const auto_renew = try utils.parseAccountId(allocator, auto_renew_str);
+        _ = try tx.setAutoRenewAccountId(auto_renew);
+    }
+    
+    if (utils.getString(p, "maxAutomaticTokenAssociations")) |max_str| {
+        const max_associations = try std.fmt.parseInt(i64, max_str, 10);
+        _ = try tx.setMaxAutomaticTokenAssociations(@intCast(max_associations));
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn deleteContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const contract_id_str = utils.getString(p, "contractId") orelse return error.MissingContractId;
+    const contract_id = try utils.parseContractId(allocator, contract_id_str);
+    
+    var tx = hedera.contractDeleteTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setContractId(contract_id);
+    
+    if (utils.getString(p, "transferAccountId")) |transfer_str| {
+        const transfer_id = try utils.parseAccountId(allocator, transfer_str);
+        _ = try tx.setTransferAccountId(transfer_id);
+    }
+    
+    if (utils.getString(p, "transferContractId")) |transfer_str| {
+        const transfer_id = try utils.parseContractId(allocator, transfer_str);
+        _ = try tx.setTransferContractId(transfer_id);
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn executeContract(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const contract_id_str = utils.getString(p, "contractId") orelse return error.MissingContractId;
+    const contract_id = try utils.parseContractId(allocator, contract_id_str);
+    
+    var tx = hedera.contractExecuteTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setContractId(contract_id);
+    
+    if (utils.getInt(p, "gas")) |gas| {
+        _ = try tx.setGas(@intCast(gas));
+    }
+    
+    if (utils.getString(p, "payableAmount")) |amount_str| {
+        const hbar = try utils.parseHbar(amount_str);
+        _ = try tx.setPayableAmount(hbar);
+    }
+    
+    if (utils.getString(p, "functionParameters")) |params_hex| {
+        const params_len = params_hex.len / 2;
+        const params_bytes = try allocator.alloc(u8, params_len);
+        defer allocator.free(params_bytes);
+        _ = try std.fmt.hexToBytes(params_bytes, params_hex);
+        _ = try tx.setFunctionParameters(params_bytes);
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    const receipt = try tx_response.getReceipt(c);
+    
+    var response_fields = json.ObjectMap.init(allocator);
+    defer response_fields.deinit();
+    
+    _ = receipt;
+    
+    return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }

--- a/tck/methods/file_service.zig
+++ b/tck/methods/file_service.zig
@@ -42,17 +42,90 @@ pub fn createFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params:
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
 pub fn updateFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const file_id_str = utils.getString(p, "fileId") orelse return error.MissingFileId;
+    const file_id = try utils.parseFileId(allocator, file_id_str);
+    
+    var tx = hedera.fileUpdateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setFileId(file_id);
+    
+    if (utils.getString(p, "keys")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setKeys(key);
+    }
+    
+    if (utils.getString(p, "contents")) |contents_base64| {
+        const decoder = std.base64.standard.Decoder;
+        const decoded_len = try decoder.calcSizeForSlice(contents_base64);
+        const decoded = try allocator.alloc(u8, decoded_len);
+        defer allocator.free(decoded);
+        _ = try decoder.decode(decoded, contents_base64);
+        _ = try tx.setContents(decoded);
+    }
+    
+    if (utils.getString(p, "expirationTime")) |exp_str| {
+        const timestamp = try utils.parseTimestamp(exp_str);
+        _ = try tx.setExpirationTime(timestamp);
+    }
+    
+    if (utils.getString(p, "memo")) |memo| {
+        _ = try tx.setMemo(memo);
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn deleteFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const file_id_str = utils.getString(p, "fileId") orelse return error.MissingFileId;
+    const file_id = try utils.parseFileId(allocator, file_id_str);
+    
+    var tx = hedera.fileDeleteTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setFileId(file_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn appendFile(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const file_id_str = utils.getString(p, "fileId") orelse return error.MissingFileId;
+    const file_id = try utils.parseFileId(allocator, file_id_str);
+    
+    var tx = hedera.fileAppendTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setFileId(file_id);
+    
+    if (utils.getString(p, "contents")) |contents_base64| {
+        const decoder = std.base64.standard.Decoder;
+        const decoded_len = try decoder.calcSizeForSlice(contents_base64);
+        const decoded = try allocator.alloc(u8, decoded_len);
+        defer allocator.free(decoded);
+        _ = try decoder.decode(decoded, contents_base64);
+        _ = try tx.setContents(decoded);
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }

--- a/tck/methods/token_service.zig
+++ b/tck/methods/token_service.zig
@@ -81,7 +81,7 @@ pub fn createToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params
     if (utils.getInt(p, "maxSupply")) |max_supply| {
         _ = try tx.setMaxSupply(max_supply);
     }
-    _ = try tx.freezeWith(c);
+    _ = try tx.base.freezeWith(c);
     var tx_response = try tx.execute(c);
     const receipt = try tx_response.getReceipt(c);
     
@@ -99,92 +99,539 @@ pub fn createToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
 pub fn updateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenUpdateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    if (utils.getString(p, "symbol")) |symbol| {
+        _ = try tx.setTokenSymbol(symbol);
+    }
+    
+    if (utils.getString(p, "name")) |name| {
+        _ = try tx.setTokenName(name);
+    }
+    
+    if (utils.getString(p, "treasuryAccountId")) |treasury_str| {
+        const treasury = try utils.parseAccountId(allocator, treasury_str);
+        _ = try tx.setTreasuryAccountId(treasury);
+    }
+    
+    if (utils.getString(p, "adminKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setAdminKey(key);
+    }
+    
+    if (utils.getString(p, "kycKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setKycKey(key);
+    }
+    
+    if (utils.getString(p, "freezeKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setFreezeKey(key);
+    }
+    
+    if (utils.getString(p, "wipeKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setWipeKey(key);
+    }
+    
+    if (utils.getString(p, "supplyKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setSupplyKey(key);
+    }
+    
+    if (utils.getString(p, "autoRenewAccountId")) |auto_renew_str| {
+        const auto_renew = try utils.parseAccountId(allocator, auto_renew_str);
+        _ = try tx.setAutoRenewAccount(auto_renew);
+    }
+    
+    if (utils.getString(p, "autoRenewPeriod")) |period_str| {
+        const duration = try utils.parseDuration(period_str);
+        _ = try tx.setAutoRenewPeriod(duration);
+    }
+    
+    if (utils.getString(p, "expirationTime")) |exp_str| {
+        const timestamp = try utils.parseTimestamp(exp_str);
+        _ = try tx.setExpirationTime(timestamp);
+    }
+    
+    if (utils.getString(p, "memo")) |memo| {
+        _ = try tx.setTokenMemo(memo);
+    }
+    
+    if (utils.getString(p, "feeScheduleKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setFeeScheduleKey(key);
+    }
+    
+    if (utils.getString(p, "pauseKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setPauseKey(key);
+    }
+    
+    if (utils.getString(p, "metadata")) |metadata| {
+        _ = try tx.setMetadata(metadata);
+    }
+    
+    if (utils.getString(p, "metadataKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setMetadataKey(key);
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn deleteToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenDeleteTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn updateTokenFeeSchedule(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenFeeScheduleUpdateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    if (p.object.get("customFees")) |custom_fees| {
+        for (custom_fees.array.items) |fee| {
+            const fee_collector_str = utils.getString(fee, "feeCollectorAccountId") orelse continue;
+            const fee_collector = try utils.parseAccountId(allocator, fee_collector_str);
+            
+            if (fee.object.get("fixedFee")) |fixed| {
+                const amount = utils.getInt(fixed, "amount") orelse 0;
+                const hbar_amount = try hedera.Hbar.fromTinybars(amount);
+                var custom_fee = hedera.CustomFixedFee.init();
+                _ = try custom_fee.setAmount(@intCast(hbar_amount.toTinybars()));
+                _ = try custom_fee.setFeeCollectorAccountId(fee_collector);
+                _ = try tx.addCustomFee(hedera.CustomFee{ .fixed = custom_fee });
+            } else if (fee.object.get("fractionalFee")) |fractional| {
+                const numerator = utils.getInt(fractional, "numerator") orelse 0;
+                const denominator = utils.getInt(fractional, "denominator") orelse 1;
+                const min = utils.getInt(fractional, "minimumAmount") orelse 0;
+                const max = utils.getInt(fractional, "maximumAmount") orelse 0;
+                var custom_fee = hedera.CustomFractionalFee.init();
+                _ = try custom_fee.setNumerator(@intCast(numerator));
+                _ = try custom_fee.setDenominator(@intCast(denominator));
+                _ = try custom_fee.setMinimumAmount(@intCast(min));
+                _ = try custom_fee.setMaximumAmount(@intCast(max));
+                _ = try custom_fee.setFeeCollectorAccountId(fee_collector);
+                _ = try tx.addCustomFee(hedera.CustomFee{ .fractional = custom_fee });
+            }
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn associateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenAssociateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setAccountId(account_id);
+    
+    if (p.object.get("tokenIds")) |token_ids| {
+        for (token_ids.array.items) |token_str| {
+            const token_id = try utils.parseTokenId(allocator, token_str.string);
+            _ = try tx.addTokenId(token_id);
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn dissociateToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenDissociateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setAccountId(account_id);
+    
+    if (p.object.get("tokenIds")) |token_ids| {
+        for (token_ids.array.items) |token_str| {
+            const token_id = try utils.parseTokenId(allocator, token_str.string);
+            _ = try tx.addTokenId(token_id);
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn pauseToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenPauseTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn unpauseToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenUnpauseTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn freezeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenFreezeTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    _ = try tx.setAccountId(account_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn unfreezeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenUnfreezeTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    _ = try tx.setAccountId(account_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn grantTokenKyc(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenGrantKycTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    _ = try tx.setAccountId(account_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn revokeTokenKyc(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenRevokeKycTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    _ = try tx.setAccountId(account_id);
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn mintToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenMintTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    if (utils.getInt(p, "amount")) |amount| {
+        _ = try tx.setAmount(@intCast(amount));
+    }
+    
+    if (p.object.get("metadata")) |metadata_array| {
+        for (metadata_array.array.items) |metadata| {
+            _ = try tx.addMetadata(metadata.string);
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    const receipt = try tx_response.getReceipt(c);
+    
+    var response_fields = json.ObjectMap.init(allocator);
+    defer response_fields.deinit();
+    
+    if (receipt.serial_numbers.len > 0) {
+        var serial_array = std.ArrayList(json.Value).init(allocator);
+        defer serial_array.deinit();
+        for (receipt.serial_numbers) |serial| {
+            try serial_array.append(json.Value{ .integer = @intCast(serial) });
+        }
+        try response_fields.put("serialNumbers", json.Value{ .array = serial_array });
+    }
+    
+    return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
 pub fn burnToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    var tx = hedera.tokenBurnTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    
+    if (utils.getInt(p, "amount")) |amount| {
+        _ = try tx.setAmount(@intCast(amount));
+    }
+    
+    if (p.object.get("serialNumbers")) |serial_array| {
+        for (serial_array.array.items) |serial| {
+            _ = try tx.addSerialNumber(@intCast(serial.integer));
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn wipeToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const token_id_str = utils.getString(p, "tokenId") orelse return error.MissingTokenId;
+    const token_id = try utils.parseTokenId(allocator, token_id_str);
+    
+    const account_id_str = utils.getString(p, "accountId") orelse return error.MissingAccountId;
+    const account_id = try utils.parseAccountId(allocator, account_id_str);
+    
+    var tx = hedera.tokenWipeTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTokenId(token_id);
+    _ = try tx.setAccountId(account_id);
+    
+    if (utils.getInt(p, "amount")) |amount| {
+        _ = try tx.setAmount(@intCast(amount));
+    }
+    
+    if (p.object.get("serialNumbers")) |serial_array| {
+        for (serial_array.array.items) |serial| {
+            _ = try tx.addSerialNumber(@intCast(serial.integer));
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn claimToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    return try utils.createResponse(allocator, "METHOD_NOT_FULLY_IMPLEMENTED", null);
 }
 pub fn airdropToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    var tx = hedera.tokenAirdropTransaction(allocator);
+    defer tx.deinit();
+    
+    if (p.object.get("tokenTransfers")) |transfers| {
+        for (transfers.array.items) |transfer| {
+            const token_str = utils.getString(transfer, "tokenId") orelse continue;
+            const account_str = utils.getString(transfer, "accountId") orelse continue;
+            const amount_int = utils.getInt(transfer, "amount") orelse continue;
+            _ = utils.getInt(transfer, "expectedDecimals");
+            
+            const token_id = try utils.parseTokenId(allocator, token_str);
+            const account_id = try utils.parseAccountId(allocator, account_str);
+            
+            _ = try tx.addTokenTransfer(token_id, account_id, @as(i64, @intCast(amount_int)));
+        }
+    }
+    
+    if (p.object.get("nftTransfers")) |transfers| {
+        for (transfers.array.items) |transfer| {
+            const token_str = utils.getString(transfer, "tokenId") orelse continue;
+            const sender_str = utils.getString(transfer, "senderAccountId") orelse continue;
+            const receiver_str = utils.getString(transfer, "receiverAccountId") orelse continue;
+            const serial_int = utils.getInt(transfer, "serialNumber") orelse continue;
+            
+            const token_id = try utils.parseTokenId(allocator, token_str);
+            _ = try utils.parseAccountId(allocator, sender_str);
+            const receiver = try utils.parseAccountId(allocator, receiver_str);
+            const nft_id = hedera.NftId.init(token_id, @intCast(serial_int));
+            
+            _ = try tx.addNftTransfer(nft_id, receiver);
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn cancelAirdrop(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
     _ = client;
     _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    return try utils.createResponse(allocator, "METHOD_NOT_FULLY_IMPLEMENTED", null);
 }
 pub fn rejectToken(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    var tx = hedera.tokenRejectTransaction(allocator);
+    defer tx.deinit();
+    
+    const owner_str = utils.getString(p, "ownerId");
+    if (owner_str) |owner| {
+        const owner_id = try utils.parseAccountId(allocator, owner);
+        _ = try tx.setOwnerId(owner_id);
+    }
+    
+    if (p.object.get("tokenIds")) |token_ids| {
+        for (token_ids.array.items) |token_str| {
+            const token_id = try utils.parseTokenId(allocator, token_str.string);
+            _ = try tx.addTokenId(token_id);
+        }
+    }
+    
+    if (p.object.get("nftIds")) |nft_ids| {
+        for (nft_ids.array.items) |nft| {
+            const token_str = utils.getString(nft, "tokenId") orelse continue;
+            const serial = utils.getInt(nft, "serialNumber") orelse continue;
+            const token_id = try utils.parseTokenId(allocator, token_str);
+            const nft_id = hedera.NftId.init(token_id, @intCast(serial));
+            _ = try tx.addNftId(nft_id);
+        }
+    }
+    
+    _ = try tx.base.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }

--- a/tck/methods/topic_service.zig
+++ b/tck/methods/topic_service.zig
@@ -44,17 +44,105 @@ pub fn createTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params
     return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }
 pub fn updateTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const topic_id_str = utils.getString(p, "topicId") orelse return error.MissingTopicId;
+    const topic_id = try utils.parseTopicId(allocator, topic_id_str);
+    
+    var tx = try hedera.topicUpdateTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTopicId(topic_id);
+    
+    if (utils.getString(p, "adminKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setAdminKey(key);
+    }
+    
+    if (utils.getString(p, "submitKey")) |key_str| {
+        var private_key = try utils.parsePrivateKey(allocator, key_str);
+        defer private_key.deinit();
+        const key = hedera.Key.fromPublicKey(private_key.getPublicKey());
+        _ = try tx.setSubmitKey(key);
+    }
+    
+    if (utils.getString(p, "memo")) |memo| {
+        _ = try tx.setTopicMemo(memo);
+    }
+    
+    if (utils.getString(p, "expirationTime")) |exp_str| {
+        const timestamp = try utils.parseTimestamp(exp_str);
+        _ = try tx.setExpirationTime(timestamp);
+    }
+    
+    if (utils.getString(p, "autoRenewPeriod")) |period_str| {
+        const duration = try utils.parseDuration(period_str);
+        _ = try tx.setAutoRenewPeriod(duration);
+    }
+    
+    if (utils.getString(p, "autoRenewAccountId")) |account_str| {
+        const account = try utils.parseAccountId(allocator, account_str);
+        _ = try tx.setAutoRenewAccountId(account);
+    }
+    
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn deleteTopic(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const topic_id_str = utils.getString(p, "topicId") orelse return error.MissingTopicId;
+    const topic_id = try utils.parseTopicId(allocator, topic_id_str);
+    
+    var tx = try hedera.topicDeleteTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTopicId(topic_id);
+    
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    _ = try tx_response.getReceipt(c);
+    
+    return try utils.createResponse(allocator, "SUCCESS", null);
 }
 pub fn submitTopicMessage(allocator: std.mem.Allocator, client: ?*hedera.Client, params: ?json.Value) !json.Value {
-    _ = client;
-    _ = params;
-    return try utils.createResponse(allocator, "NOT_IMPLEMENTED", null);
+    const c = client orelse return error.ClientNotConfigured;
+    const p = params orelse return error.MissingParams;
+    
+    const topic_id_str = utils.getString(p, "topicId") orelse return error.MissingTopicId;
+    const topic_id = try utils.parseTopicId(allocator, topic_id_str);
+    
+    var tx = hedera.topicMessageSubmitTransaction(allocator);
+    defer tx.deinit();
+    
+    _ = try tx.setTopicId(topic_id);
+    
+    if (utils.getString(p, "message")) |message_base64| {
+        const decoder = std.base64.standard.Decoder;
+        const decoded_len = try decoder.calcSizeForSlice(message_base64);
+        const decoded = try allocator.alloc(u8, decoded_len);
+        defer allocator.free(decoded);
+        _ = try decoder.decode(decoded, message_base64);
+        _ = try tx.setMessage(decoded);
+    }
+    
+    _ = try tx.freezeWith(c);
+    var tx_response = try tx.execute(c);
+    const receipt = try tx_response.getReceipt(c);
+    
+    var response_fields = json.ObjectMap.init(allocator);
+    defer response_fields.deinit();
+    
+    if (receipt.topic_sequence_number > 0) {
+        try response_fields.put("sequenceNumber", json.Value{ .integer = @intCast(receipt.topic_sequence_number) });
+    }
+    
+    return try utils.createResponse(allocator, "SUCCESS", response_fields);
 }


### PR DESCRIPTION
  This commit introduces a major refactoring of the query and transaction submission logic to improve robustness,
  extensibility, and alignment with the Hedera protobuf definitions. The Technology Compatibility Kit (TCK) has also been
  significantly expanded with new service methods.

  Key changes include the refactoring of queries and transactions. This involves centralizing gRPC service and method routing
  within base structs. Transactions and queries now build their own protobuf bodies, ensuring correct field numbers and types.
   Generic query execution has been replaced with a more direct control over the payload. The freezeWith method on
  transactions now consistently returns a pointer to the transaction.

  The TCK has been expanded with new service methods for Schedule, Node, and various queries like getAccountInfo and
  getAccountBalance. TCK service method implementations have been simplified, removing boilerplate code. The main build.zig
  file has also been cleaned up by removing the example builds.

  API improvements include the removal of deprecated fields like proxy_account_id and the standardization of function naming.
  TopicCreateTransaction and TopicMessageSubmitTransaction have been refactored for consistency.

  New features include a CostQuery for estimating transaction fees and an AbstractTokenTransferTransaction to handle common
  token transfer logic.